### PR TITLE
Fix bug in SI set_vacuum_chamber

### DIFF
--- a/pymodels/BO_V05_04/lattice.py
+++ b/pymodels/BO_V05_04/lattice.py
@@ -303,7 +303,7 @@ def create_lattice(energy=energy, optics_mode=None):
     set_num_integ_steps(the_ring)
 
     # -- define vacuum chamber for all elements
-    set_vacuum_chamber(the_ring)
+    the_ring = set_vacuum_chamber(the_ring)
 
     return the_ring
 
@@ -434,3 +434,5 @@ def set_vacuum_chamber(the_ring):
         the_ring[i].hmax = extraction_vchamber[1]
         the_ring[i].vmin = extraction_vchamber[2]
         the_ring[i].vmax = extraction_vchamber[3]
+
+    return the_ring

--- a/pymodels/LI_V01_01/lattice.py
+++ b/pymodels/LI_V01_01/lattice.py
@@ -165,7 +165,7 @@ def create_lattice(optics_mode = default_optics_mode, operation_mode = default_o
     set_num_integ_steps(the_line)
 
     # -- define vacuum chamber for all elements
-    set_vacuum_chamber(the_line)
+    the_line = set_vacuum_chamber(the_line)
 
     return the_line, twiss_at_match
 
@@ -260,3 +260,5 @@ def set_vacuum_chamber(the_line):
         the_line[i].hmax = +0.018
         the_line[i].vmin = -0.018
         the_line[i].vmax = +0.018
+
+    return the_line

--- a/pymodels/SI_V24_04/lattice.py
+++ b/pymodels/SI_V24_04/lattice.py
@@ -4,10 +4,13 @@ In this module the lattice of the corresponding accelerator is defined.
 """
 
 import math as _math
+import numpy as _np
+
 import lnls as _lnls
+import mathphys as _mp
 from pyaccel import lattice as _pyacc_lat, elements as _pyacc_ele, \
     accelerator as _pyacc_acc
-import mathphys as _mp
+
 from . import segmented_models as _segmented_models
 
 default_optics_mode = 'S05.01'
@@ -588,7 +591,7 @@ def set_vacuum_chamber(the_ring, mode=default_optics_mode):
     idb_vchamber = [-0.004, 0.004, -0.00225, 0.00225]
     ida_vchamber = [-0.012, 0.012, -0.004, 0.004]
     bc_hfield_vchamber = [-0.004, 0.004, -0.004, 0.004]
-    inj_vchamber = [-0.030, 0.030, -0.012, 0.012]
+    inj_vchamber = [-0.030, 0.012, -0.012, 0.012]
     idp_vchamber = idb_vchamber if mode.startswith('S05') else ida_vchamber
 
     # Set ordinary Vacuum Chamber
@@ -600,32 +603,36 @@ def set_vacuum_chamber(the_ring, mode=default_optics_mode):
     bpm = _pyacc_lat.find_indices(the_ring, 'fam_name', 'BPM')
     the_ring = _pyacc_lat.shift(the_ring, bpm[0])
 
-    # Set in-vacuum ids vacuum chamber
-    idb = _pyacc_lat.find_indices(the_ring, 'fam_name', 'id_endb')
-    idb_list = []
-    for i in range(len(idb)//2):
-        idb_list.extend(range(idb[2*i], idb[2*i+1]+1))
-    for i in idb_list:
-        e = the_ring[i]
-        e.hmin, e.hmax, e.vmin, e.vmax = idb_vchamber
+    # NOTE: Insertion devices vchamber temporarily off
 
-    # Set other ids vacuum chamber
-    ida = _pyacc_lat.find_indices(the_ring, 'fam_name', 'id_enda')
-    ida_list = []
-    for i in range(len(ida)//2):
-        ida_list.extend(range(ida[2*i], ida[2*i+1]+1))
-    for i in ida_list:
-        e = the_ring[i]
-        e.hmin, e.hmax, e.vmin, e.vmax = ida_vchamber
+    # # Set in-vacuum ids vacuum chamber
+    # idb = _pyacc_lat.find_indices(the_ring, 'fam_name', 'id_endb')
+    # print(idb)
+    # idb_list = []
+    # for i in range(len(idb)//2):
+    #     idb_list.extend(range(idb[2*i], idb[2*i+1]+1))
+    # print(idb_list)
+    # for i in idb_list:
+    #     e = the_ring[i]
+    #     e.hmin, e.hmax, e.vmin, e.vmax = idb_vchamber
 
-    # Set other ids vacuum chamber
-    idp = _pyacc_lat.find_indices(the_ring, 'fam_name', 'id_endp')
-    idp_list = []
-    for i in range(len(idp)//2):
-        idp_list.extend(range(idp[2*i], idp[2*i+1]+1))
-    for i in idp_list:
-        e = the_ring[i]
-        e.hmin, e.hmax, e.vmin, e.vmax = idp_vchamber
+    # # Set other ids vacuum chamber
+    # ida = _pyacc_lat.find_indices(the_ring, 'fam_name', 'id_enda')
+    # ida_list = []
+    # for i in range(len(ida)//2):
+    #     ida_list.extend(range(ida[2*i], ida[2*i+1]+1))
+    # for i in ida_list:
+    #     e = the_ring[i]
+    #     e.hmin, e.hmax, e.vmin, e.vmax = ida_vchamber
+
+    # # Set other ids vacuum chamber
+    # idp = _pyacc_lat.find_indices(the_ring, 'fam_name', 'id_endp')
+    # idp_list = []
+    # for i in range(len(idp)//2):
+    #     idp_list.extend(range(idp[2*i], idp[2*i+1]+1))
+    # for i in idp_list:
+    #     e = the_ring[i]
+    #     e.hmin, e.hmax, e.vmin, e.vmax = idp_vchamber
 
     # Shift the ring back.
     the_ring = _pyacc_lat.shift(the_ring, len(the_ring)-bpm[0])
@@ -650,6 +657,12 @@ def set_vacuum_chamber(the_ring, mode=default_optics_mode):
         rho = lng/ang
         if rho < rho0:
             e.hmin, e.hmax, e.vmin, e.vmax = bc_hfield_vchamber
+    indices = _pyacc_lat.find_indices(the_ring, 'fam_name', 'mc')
+    for i in indices:
+        e = the_ring[i]
+        e.hmin, e.hmax, e.vmin, e.vmax = bc_hfield_vchamber
+        e = the_ring[i + 1]
+        e.hmin, e.hmax, e.vmin, e.vmax = bc_hfield_vchamber
 
     return the_ring
 

--- a/pymodels/SI_V24_04/lattice.py
+++ b/pymodels/SI_V24_04/lattice.py
@@ -545,7 +545,7 @@ def create_lattice(mode=default_optics_mode, simplified=False):
     set_num_integ_steps(the_ring)
 
     # -- define vacuum chamber for all elements
-    set_vacuum_chamber(the_ring)
+    the_ring = set_vacuum_chamber(the_ring)
 
     return the_ring
 
@@ -596,10 +596,9 @@ def set_vacuum_chamber(the_ring, mode=default_optics_mode):
         e = the_ring[i]
         e.hmin, e.hmax, e.vmin, e.vmax = other_vchamber
 
-    # Shift the ring to do not begin between id markers
+    # Shift the ring so that lattice does not begin between id markers
     bpm = _pyacc_lat.find_indices(the_ring, 'fam_name', 'BPM')
     the_ring = _pyacc_lat.shift(the_ring, bpm[0])
-
 
     # Set in-vacuum ids vacuum chamber
     idb = _pyacc_lat.find_indices(the_ring, 'fam_name', 'id_endb')
@@ -651,6 +650,8 @@ def set_vacuum_chamber(the_ring, mode=default_optics_mode):
         rho = lng/ang
         if rho < rho0:
             e.hmin, e.hmax, e.vmin, e.vmax = bc_hfield_vchamber
+
+    return the_ring
 
 
 def get_optics_mode(mode=default_optics_mode):

--- a/pymodels/TB_V03_02/lattice.py
+++ b/pymodels/TB_V03_02/lattice.py
@@ -184,7 +184,7 @@ def create_lattice(optics_mode=default_optics_mode):
     set_num_integ_steps(the_line)
 
     # -- define vacuum chamber for all elements
-    set_vacuum_chamber(the_line)
+    the_line = set_vacuum_chamber(the_line)
 
     return the_line, twiss_at_start
 
@@ -290,3 +290,5 @@ def set_vacuum_chamber(the_line):
         the_line[i].hmax = +0.0117
         the_line[i].vmin = -0.0117
         the_line[i].vmax = +0.0117
+
+    return the_line

--- a/pymodels/TB_V04_01/lattice.py
+++ b/pymodels/TB_V04_01/lattice.py
@@ -168,7 +168,7 @@ def create_lattice(optics_mode=default_optics_mode):
     set_num_integ_steps(the_line)
 
     # -- define vacuum chamber for all elements
-    set_vacuum_chamber(the_line)
+    the_line = set_vacuum_chamber(the_line)
 
     return the_line, twiss_at_start
 
@@ -341,3 +341,5 @@ def set_vacuum_chamber(the_line):
         the_line[i].hmax = +0.0117
         the_line[i].vmin = -0.0117
         the_line[i].vmax = +0.0117
+
+    return the_line

--- a/pymodels/TS_V03_03/lattice.py
+++ b/pymodels/TS_V03_03/lattice.py
@@ -217,7 +217,7 @@ def create_lattice(optics_mode=default_optics_mode):
     set_num_integ_steps(the_line)
 
     # -- define vacuum chamber for all elements
-    set_vacuum_chamber(the_line)
+    the_line = set_vacuum_chamber(the_line)
 
     return the_line, twiss_at_start
 
@@ -306,3 +306,5 @@ def set_vacuum_chamber(the_line):
         the_line[i].hmax = +0.0150
         the_line[i].vmin = -0.0035
         the_line[i].vmax = +0.0035
+
+    return the_line

--- a/pymodels/TS_V04_01/lattice.py
+++ b/pymodels/TS_V04_01/lattice.py
@@ -138,7 +138,7 @@ def create_lattice(optics_mode=default_optics_mode):
     set_num_integ_steps(the_line)
 
     # -- define vacuum chamber for all elements
-    set_vacuum_chamber(the_line)
+    the_line = set_vacuum_chamber(the_line)
 
     return the_line, twiss_at_start
 
@@ -289,3 +289,5 @@ def set_vacuum_chamber(the_line):
         the_line[i].hmax = +0.0150
         the_line[i].vmin = -0.0035
         the_line[i].vmax = +0.0035
+
+    return the_line


### PR DESCRIPTION
This bug has been lurking for almost four years now, when model `SI_V20_01` was created ... 
It was introduced in commit 116daf7886f0ea9dda05e6fe12d851a82a5377ce when the model was shifted in order to introduce physical limits for ID vacuum chambers. The shifting function creates a new `the_ring` which was not passed back to the main `create_lattice` function.

Although this bug affects only SI model, I standardized the code for the other accelerators.