### PR TITLE
Add SI_V25_01

### DIFF
--- a/LATTICES-VERSIONS.txt
+++ b/LATTICES-VERSIONS.txt
@@ -1,0 +1,376 @@
+Storage Ring
+============
+
+SI.V25.01: nov/2020
+  - Change storage ring nominal circumference from 518.3960 m to 518.3899 m, so as to keep the current RF
+    frequency being used [499663824.38 Hz]. Girders with be moved inwards and realigned.
+
+SI.V24.04: jul/2019
+  - Update girder definition, the difference is at M1 (consequently M2) parts, the previous model considers that there is a girder containing only B1 dipole. The present model is based on real girder installation where the girder mentioned contains B1 but also a QD and a SD.
+
+SI.V24.03: jun/2019
+  - Added average BC seg models based on multipole measurement fieldmap analysis
+    around average model trajectory.
+
+SI.V24.02: jan/2019
+  - Added average B1 and B2 seg models based on multipole measurement fieldmap analysis
+    around average model trajectory.
+  - (to be done) individual B2 models based on measurements
+  - (to be done) individual B1 models based on measurements
+  - (to be done) updated girder definitions
+
+SI.V24.01: oct/2018
+  - New BC model-13
+  - Update model for FC1 (FCH+FCV+FCQ) with 84 mm (from eff. length of model-06)
+  - Update model for FC2 (FCH+FCV) with 82 mm (from eff. length of rotated model-06)
+
+SI.V23.01: jun/2018
+  - In 29/05/2018 James told us by an email sent to Fernando de Sá that the
+    magnets that will be used as the fast correctors close to the BC magnet
+    will have the shape of a normal quadrupole in the sections where there
+    are the diagnostic beamlines. Hence it will not be possible to have skew
+    quads there.
+
+    sirius_si_family_data was changed so as to remove these 10 corrector skew quads just upstream
+    BC, in those xxC2 straights where B2 diagnostic beamlines will be present.
+
+  - FCQ family was split in 2: FC1 (FCH+FCV+FCQ) and FC2 (FCH+FCV)
+
+SI.V22.04: may/2018
+  - Update marker positions of diagnostics elements, according to allocation table in sirius wiki.
+
+SI.V22.03: may/2018
+  - Make SI.E22.02 the official version, since its impact of beam quality has
+    been approved.
+  - Updated location of tune picks. they had changed in Aug/2017 but the AT lattice has not been updated.
+
+SI.E22.02: april/2018
+   - Study of new spec of sextupole errors (multipole) based on bench measurements.
+     (for details, see Luana's email of 2018-04-23 to ximenes)
+     Multipole errors:
+     n     Systematic   Random   Random
+            (normal)   (normal)  (skew)
+     3       0         7e-04     5e-04
+     4       3.4e-04   5e-04     5e-04
+     5       0         4e-04     5e-05
+     6      -1.0e-03   2e-04     9e-05
+     8      -9.3e-04   0         0
+     14      1.2e-03   0         0
+     Magnetic center offset
+     x0 = (-23 ± 7) µm
+     y0 = (-17 ± 5) µm
+     Roll
+     (-0.02 ± 0.17) mrad
+
+SI.V22.02: august/2017
+   - New BC model 12
+
+SI.V22.01: may/2017
+   - The BPM upstream of dipole B2 was moved by 50mm (closer to B2) to fit in the girder. Modification in sectors C1 and C3. This change was requested by the Projects Group.
+
+SI.V21.03: mar/2017
+   - New fast corrector model 03.
+   - Updated models of Q14, Q20, Q30 quadrupoles.
+   - Updated model of sextupoles.
+   - Updated models of B1 (model 09) and B2 (model 08).
+
+SI.V21.02 - S05.03: mar/2017
+   - A new operation mode (S05.03) has been created with symmetrized optics and same tunes and chromaticites as S05.01.
+
+SI.V21.02 - S05.02: mar/2017
+   - The new B1 and B2 models introduced non-zero dispersion at insertion straights as well as assymetries in the optical functions. The mode S05.02 is generated with symmetrized optics and sames tunes as S05.01. The horizontal chromaticity increased by ~ +4.5 and the emittance reduced to 0.248 nm.
+
+SI.V21.02: feb/2017
+   - New models for B1 (model-8) and B2 (model-7) are implemented.
+
+SI.E21.01: jan/2017
+   - Update in dipole models (B1 model 07, B2 model 08)
+     (mechanical design approval still pending...)
+   - Update in famnames according to new naming conventions
+   - Add systematic multipoles for fast correctors CH, CV, QS (based on fieldmap analysis of corrector model 02)
+   - Added fields in damily_data so that sys multi errors can be applied to
+     CV/QS accoring to implementation in sextupoles or seprate magnets
+
+SI.V21.01: oct/2016
+   - Modifications proposed in SI.E20.01 are implemented oficialy.
+
+SI.E20.01: set/2016
+   - Study of the effect on residual orbit correction at BC due to modification of the BPM position from one side to the other side of the quadrupole. This modification avoids collision between BC beamline exit and the BPM. The fast corrector is transfered to the other side of the sextupole.
+
+SI.V20.01: jul/2016.
+   - (ago/2016) The FC (fast corrector) position in low beta matching sectors has been changed by 9 mm to avoid collision with quadrupole coils. Since this is change doesn't affect any of the calculations already performed, we kept the same version, SI.V20.01.
+   - The extra sextupole magnet SDx4 has been removed and the stand-alone booster vertical corrector CV is returned. An additional coil is introduced in the fast corrector to generate the QS necessary to apply BBA in the BPM next to BC. A new family FCQ (fast correctors with QS coil) has been created.
+   - FCQ is moved from the central region of the C2 sector to its extremity, close to dipole BC and the BPM.
+   - The QS in sextupole SDx2 has been removed. The total number of QS is 100 in this version.
+
+SI.E19.03: jul/2016.
+    - Number of QS: 100 (as in SI.E19.01). The fast corretor in the middle of C2 is moved to the extremity close to BC. In this way the same magnet is used for FCH, FCV and QS.
+
+SI.E19.02: jul/2016.
+    - skew quads added to all fast correctors, QS of SDx0 removed. total: 150 QS
+
+SI.E19.01: jul/2016.
+    - QS of SDx2 in C4 sectors are removed. Total number of QS: 100
+
+SI.V19: jun/2016.
+    - AAn extra sextupole magnet SDx4 in straight C2 close to BC has been added to allow BBA in the BPM close to BC. Only the QS and CV coils are used, the main sextupole coils are not used. The stand-alone CV has been removed.
+
+SI.V18: jun/2016. (current documented version - in progress).
+    - QS coils are 'turned-on' in some sextupoles to allow for BBA in BPMs close to them: SDx2 in sector C1 and SDx3 in sector C3. x = A, B, P
+    - Sextupoles containing QS and CH/CV in the matching cells of high beta sections (A) have been exchanged to allow BBA in the BPM close to SFA0. In summary, CH/CV moved to SDA0 and QS moved to SFA0.
+    - For the low beta sections (B and P) the original configuration is preserved (that is CH/CV in SFB0/SFP0 and QS in SDB0/SDP0) since there are quadrupoles QDB2 close to the BPM.
+    - The total number of QS in the ring increased from 80 to 120.
+
+SI.V17: jun/2016.
+    - Corrector CV and BPM next to BC moved away from it by 70 mm and 40 mm respectively.
+    - Position of dipole kicker (DIPK) moved closer to nonlinear kicker NLK.
+
+SI.V16: apr/2016.
+    - Symmetry 5 optics with one high and three consecutive low beta function straight sections. There are 21 independent sextupole families.
+
+SI.V15: apr/2016.
+    - Symmetry 5 optics with one high and three consecutive low beta function straight sections. There are 28 independent sextupole families.
+
+SI.V14: dec/2015
+    - Default sextupole strengths and optics mode has moved to C03, making the dynamics more robust to ID perturbations.
+    - The distance between dipole B1 and quadrupoles QDB1 and QDA (in the matching section) has been increased by 10 cm to allow moving the pumping station from B1B upstream to downstream.
+    - To keep the same ring circumference, the long straight sections have been reduced by the same amount.
+    - Fast correctors at the injection and RF cavity straight sections have been restored. In this way, all straight sections are the same regarding fast correctors.
+
+SI.V13: oct/2015.
+    - A new BC magnet design with a physical length of 912.52 mm (with end-plates). High field region is narrower in this new design.
+    - injection point has moved due to new transfer line TS.V02. On-axis kicker and PMM moved as well. Lattice BPMs are kept in injection straight section (in version V12 they were removed).
+    - Fast correctors at the injection and RF cavity straight sections have been removed
+    - Default optics mode C02 is optimized with Insertion Devices included to avoid 4-th order resonance that shows up and that was reducing the beam long-term stability.
+    - (modelling) Also systematic multipoles from fieldmap analysis of the 3D magnet model have been added to the nominal lattice model.
+    - (modelling) In the model all magnet lengths were truncated to multiples of millimeters.
+
+SI.V12: oct/2015.
+    - New slow correction system so that orbit may be better corrected at radiation exits. The modifications are:
+    - All radiation source points, comprising ID straights and BC dipoles, are now surrounded by BPMs, there is no longer any magnetic element from the lattice between the BPM and the light source point.
+    - A BPM from the C2 section has been removed, decreasing the total number of BPMs in the ring by 20 units, from 180 to 160.
+    - A vertical corrector has been added before BC, next to it. This corrector can be of the Booster CV type since it has the same maximum strength specification. In total there are 20 of these correctors in the ring.
+    - Another extra vertical corrector coil combined with the sextupole SF2 in sector C3 has been added. This sextupole, which had only CH before, will now have CH and CV coils.
+    - The total number of vertical corrector power supplies has increased by 40 in this new version, from 120 to 160. The number of horizontal correctors remains the same, 120.
+    - The fast corrector positions have changed according to the new arrangement of BPMs.
+    - The sextupoles SF2J and SF2K were displaced by a small amount to allow placing the fast correctors closer to BC.
+
+SI.V10: jun/2015.
+    - Change in the straight sections: QDA/QDB1 changed positions with SDA/SDB sextupoles; QDB2 brought closer to QFB; longer straight sections (6.5/7.5m).
+    - New Q14, Q20 and Q30 models (different physical lengths and systematics multipoles).
+    - Change of sextupole family names: from sd1/sf1/sd2/sd3/sf2/sd6/sf4/sd5/sd4/sf3 to sd1j/sf1j/sd2j/sd3j/sf2j/sd1k/sf1k/sd2k/sd3k/sf2k.
+    - The number of horizontal correctors used in the correction loop was diminished to 120. Now the sextupoles with correctors are: CH --> sd1j/sf2j/sd1k/sf2k/sfa/sfb | CV --> sd1j/sd3j/sd1k/sd3k/sfa/sfb.
+
+SI.V09: jun/2015.
+    - The magnets B3 and BC were redesigned into a single permanent magnet, named BC. The central field changed from 2T to 3.2T.
+    - Few BPMs were moved: the BPMs on the straights were moved to the other side of the focalizing quadrupole, due to request of the vacuum group; the BPM close to the B1 dipole was moved to be close to the B2 dipole.
+
+SI.V08: mar/2015.
+    - Skew quadrupole correctors moved from sextupole to fast correctors magnets.
+
+SI.V07: mar/2015.
+    - Small dislocations in sextupoles and quadrupoles. Circumference pinned to 518.396 m. Fast correctors CHF and CVF moved out from sextupole magnets. New MOGA optimization adopted (firstRun_000493.m).
+    - Skew quadrupole correctors in SDA, SF1, SF4 and SDB sextupole families. New BC model with 12 segments being used.
+
+SI.V06: fev/2015.
+    - Length of quadrupoles: 14 cm, 20 cm and 30 cm.
+
+SI.V05: fev/2015.
+    - The length of the quadrupoles are changed as follows: from 25 cm and 14 cm to 20 cm; from 34 cm to 25 cm.
+
+SI.V04: fev/2015.
+    - In this version the model for dipoles B1, B2 and B3 have been changed to reflect the decision to use rectangular straight unit blocks to composed them.
+    - Each dipole magnetic length considers 396 mm blocks, 7 mm spacing between blocks and 29 mm gap. Note that the entrance and exit angle for all dipoles are now the same.
+    - The BC deflection is increased from 1.4 to 1.468 degrees, according to the magnet model. B1 uses 2 blocks, B2 uses 3 blocks and B3 uses 1 block.
+
+SI.V03: set/2014.
+    - Corretoras H e V estão juntas. Retirado um bpm (saída do B3) por trecho. Redefinidas onde as corretoras rápidas ficarão.
+
+SI.V02: set/2014.
+    - QFA passou de 34 cm para 25 cm. Ajustes na distância SEXT-QUAD. Corretoras aumentadas de 10 cm para 12 cm incluindo bobina. BPMs ao lado do B3 reposicionados para perto dos quadrupolos QF4 para otimizar BBA.
+
+SI.V01: ago/2014.
+    - Familias de sextupolos no arco cromático foi separada: famílias antes do BC ficaram independentes das famílias depois do BC, ou seja não temos mais simetria de espelho para os sextupolos em relação ao BC.
+
+SI.V00: ago/2014.
+    - Esta é a mesma versão que a v500. Reniciamos a numeração das versões.
+
+SI.V500: nov/2013.
+    - Comprimento dos trechos retos ajustados para freqüência de RF de 499.654MHz. A circunferência passou de 518.25m para 518.396m. Aumento de 2 x 0,00365m nos trechos retos de inserção LIA e LIB.
+
+SI.V403:
+    - bpms dos trechos dos IDs deslocados para posição entre SA2 e QAF (alto beta) e SB2 e QBF (baixo beta). Adicionado 1 bpm após o B3. Os sextupolos SA2 e SB2 tiveram que ser deslocados de 7 cm para mais longe dos quadrupolos.
+
+SI.V402:
+    - deslocamento de 3cm da corretora vertical para mais longe do B2.
+
+SI.V401:
+    - deslocamento de 4cm das corretoras para mais perto do B1.
+
+SI.V400:
+    - a rede que apresentou melhor resultado nos testes foi a v350, com 180 bpms, 180 corretoras horizontais e 160 corretoras verticais e ainda, com todos os bpms longe das saídas de luz e sem o bpm no centro do BC.
+    - A partr dela, fizemos a v400, que ainda possui três alterações: alguns sextupolos foram deslocados 1.5cm para mais perto do quadrupolo mais próximo, para padronizar as distâncias entre elementos em inteiros de cm;
+    - as corretoras que estavam juntas foram separadas, e as corretoras simetrizadas em relação ao BC, apesar de os bpms não serem simétricos;
+
+SI.V310:
+    - geramos uma rede com 200 bpms e 200 corretoras verticais para estudar o melhor posicionamento dos elementos, tentanto recuperar os resultados do antigo sistema de correção de órbita.
+    - redes v310, v320, v330, v340, v350 foram geradas.
+
+SI.V300:
+    - mudança dos bpms para longe das saídas de luz e junção de corretoras verticais e horizontais próximas em apenas um magneto (alteração significativa no sistema de correção de órbita);
+
+SI.V200:
+    - initial version
+
+
+TS Transport Line
+=================
+TS.V04.01: set/2019
+    - CHs were moved inside quadrupoles QF1B, QF2, QF3 and QF4.
+    - Add CVs lengths (same CVs of booster and storage ring)
+    - Include segmented model for Q14 and Q20 quadrupoles (same as storage ring quadrupoles)
+    - Adjust model to be consistent with BTS-TS.V04 CAD drawing
+    - The quadrupole QF3 is closer to the sector 3 dipole by 657.09 mm
+    - The quadrupole QF4 is closer to the sector 3 dipole by 16.2mm
+    - The quadrupole QD4B was moved away from the sector 3 dipole by 149.8mm
+    - The total length of this version is 26.97063m including septa.
+
+TS.V03.04: set/2017
+    - Update segmented model-01 of dipoles. This is mechanically identical to model-09 booster dipoles, but with lower excitation current corresponding to lower deflection angle.
+
+TS.V03.03: jan/2017
+    - Update in famnames according to new naming conventions
+
+TS.V03.02: sep/2016
+    - Updated labels for septa: thinejesept, thickejesept, thickinjsept,
+      thininjsept
+    - changed quadrupole names. added 'h' (high energy) at end to avoid PV
+      naming collision with TB
+    - removed fake 'ch' elements in the lattice. Now septa used in orbit
+      correction have to be explicited included in the algorithm (they already
+      are in the MML structure)
+    - dipole famname changed to DIPH (high energy dipoles)
+
+TS.V03.01: jun/2016
+    - Both booster extraction septa (thin and thick) had the magnetic fields increased to the same value of the storage ring injection septa. The angles are kept the same so the lengths are now shorter.
+    - The thick injection septa uses the same design as the thick extraction septum, so that there is now only one design for the thick injection and extraction septa. In this way the deflection angle of the thick injection septa is increased from 3.12 to 3.6 degree and the BTS dipole angles were reduced from 5.333 to 5.012 degree.
+
+TS.V02.M0: oct/2015
+    - BO.V02A, tentative dipole model 6 split into two parts. Its current has been adjusted as to generate nominal deflection angle while its integrated quadrupole and sextupole fields have changed. In this model the segments are pressed with one type of end plate.
+    - Thick and thin storage ring injection septa replaced by 3 identical injection septa.
+    - Updated models of quadrupoles, sextupoles with corrected effective lengths. updated segmented model of dipoles.
+
+TS.V01.M0:
+
+TS.V500.M0:
+
+TS.V300:
+
+TS.V200:
+
+TS.V100: initial version
+
+
+Booster
+=======
+
+BO.V05.04:
+    - update dipole model 09: average model based on fieldmap multipole analysis at 3GeV around reference trajectory (x0=9.1476, x_ref=28.255mm).
+      reference trajectory is built as the average segmented model trajectory based on individual RK trajectories.
+
+BO.V05.03:
+    - dipoles are sorted and each dipole model is built from analysis of measured hallprobe fieldmaps.
+    - QF quads are sorted and each model is built from analysis of measured hallprobe fieldmaps.
+    - QD quads are sorted and each model is built from analysis of measured hallprobe fieldmaps.
+
+BO.V05.02:
+    - update dipole model 09: new fmap analysis with x0=9.1013mm => x-ref=28.255 mm (value used in alignment)
+      a) default dipole model using segmented model from new analysis
+
+BO.V05.01:
+    - one BPM shifted downstream in sector 49 (extraction sector)
+    - Scrn-1 shifted 61.4 mm downstream
+    - Scrn-2 shifted 591.11 mm upstream
+
+BO.V04.01:
+    - Straight sections with the sequence (Bend-SD-CV) (there are 5 of these in the Booster): CV was moved by 100mm away from SD to avoid the dipole chamber flange. Change requested by the Vacuum Group.
+
+BO.V03.02:
+    - update sextupole model, version 03.
+    - update QD model, version 02.
+    - update QF model, version 06.
+    - update dipole model, version 09.
+    - assumed normal quadrupole errors for QSB
+    - famnames follow naming convention for lattice elements.
+    - Update model 01 of QSB (systematic errors)
+
+BO.V03.01:
+    - skew quadrupole QSB of length 10 cm added at sector 02D to introduce coupling up tp 5%.
+
+BO.E02.04:
+    - skew quadrupole QSB with length 10 cm added at sector 02D.
+    - family names updated
+    - became BO.V03
+
+BO.V02.04:
+    - New model with updated famnames (B -> DIPB)
+
+BO.E02.02:
+    - study where each dipole was split into two magnets to achieve better mechanical quality.
+    - rotating coil measurements of systematic multipoles of sextupole magnets are included.
+
+BO.E02.01:
+    - study where each dipole was split into two magnets to achieve better mechanical quality.
+    - 3D field model data for systematic multipoles of sextupoles are
+      included.
+
+BO.V02.03:
+    - New 3D field model data for systematic multipoles of sextupoles with multipole fitting of all the even monomials. (OFFICIAL)
+
+BO.V02.02:
+    - booster lattice version and optics. Dipoles are one-block magnets.
+    - rotating coil measurements of systematic multipoles of sextupole magnets are included.
+
+BO.V02.01:
+    - 3D field model data for systematic multipoles of sextupoles are included.
+
+BO.V01.M0:
+    - lengths of hardedge models for sextupoles and QD were changed from 0.2 to 0.1 meters. The centers of these magnets were also shifted along the ring.
+
+BO.V901.M0:
+
+BO.V900.M0:
+    - initial version
+
+
+TB Transport Line
+=================
+
+TB.V04.01: Nov/2019
+- New TB version to be up to date with pymodel version
+- New septum segmented model with 6D matrices over the segments
+- Last CH replaced by QS
+
+TB.V03.01: Set/2018
+    - Updated number and positions of corretors (new model with CH and CV in the same yoke), screens, bpms and other diagnostics elements according to AutoCad drawing.
+    - TB transport line defined from end of last Linac accelerating structure, thus including quadrupole triplet, quadrupole for emittance measurement and spectrometer (dipole).
+
+TB.V02.02: Aug/2018
+    - Updated dipole model-03: Minor changes in core shape, change number of turns and coil current.
+
+TB.V02.01: Aug/2017
+    - New segmented dipole model 02.
+
+TB.V01.03:
+    - famnames follow naming convention for lattice elements.
+
+TB.V01.02:
+    - new version where injection septum famname was changed.
+    - dipole famnames were changed from BN and BP to DIPL
+
+TB.V300.M0:
+
+TB.V200:
+
+TB.V100:
+    - initial version

--- a/pymodels/SI_V25_01/__init__.py
+++ b/pymodels/SI_V25_01/__init__.py
@@ -1,0 +1,21 @@
+"""SI_V24_04 model."""
+
+from .accelerator import default_cavity_on
+from .accelerator import default_radiation_on
+from .accelerator import default_vchamber_on
+from .accelerator import accelerator_data
+from .accelerator import create_accelerator
+
+from .lattice import set_rf_frequency
+from .families import family_mapping
+from .families import get_family_data
+from .families import get_girder_data
+from .families import get_section_name_mapping
+
+from .lattice import energy
+from .lattice import harmonic_number
+from .lattice import default_optics_mode, lattice_symmetry
+
+from .control_system import get_control_system_data
+
+lattice_version = accelerator_data['lattice_version']

--- a/pymodels/SI_V25_01/__init__.py
+++ b/pymodels/SI_V25_01/__init__.py
@@ -1,4 +1,4 @@
-"""SI_V24_04 model."""
+"""SI_V25_01 model."""
 
 from .accelerator import default_cavity_on
 from .accelerator import default_radiation_on

--- a/pymodels/SI_V25_01/accelerator.py
+++ b/pymodels/SI_V25_01/accelerator.py
@@ -1,0 +1,34 @@
+"""Accelerator module."""
+
+import numpy as _np
+import pyaccel as _pyaccel
+from . import lattice as _lattice
+
+
+default_cavity_on = False
+default_radiation_on = False
+default_vchamber_on = False
+
+
+def create_accelerator(optics_mode=_lattice.default_optics_mode,
+                       simplified=False):
+    """Create accelerator model."""
+    lattice = _lattice.create_lattice(mode=optics_mode,
+                                      simplified=simplified)
+    accelerator = _pyaccel.accelerator.Accelerator(
+        lattice=lattice,
+        energy=_lattice.energy,
+        harmonic_number=_lattice.harmonic_number,
+        cavity_on=default_cavity_on,
+        radiation_on=default_radiation_on,
+        vchamber_on=default_vchamber_on
+    )
+
+    return accelerator
+
+
+accelerator_data = dict()
+accelerator_data['lattice_version'] = 'SI_V25_01'
+accelerator_data['global_coupling'] = 0.01  # expected corrected value
+accelerator_data['pressure_profile'] = \
+    _np.array([[0, 518.3899], [1.333e-9]*2])  # [s [m], p [mbar]]

--- a/pymodels/SI_V25_01/control_system.py
+++ b/pymodels/SI_V25_01/control_system.py
@@ -1,0 +1,32 @@
+
+from siriuspy.namesys import SiriusPVName as _PVName, join_name as _join_name
+
+from . import families as _fams
+
+
+def get_control_system_data(lattice, fam_data=None):
+    fam_data = fam_data or _fams.get_family_data(lattice)
+    names = dict()
+
+    # Individual elements
+    quads = _fams.families_quadrupoles()
+    mags = quads[:]
+    mags.extend(['CH', 'CV', 'QS'])
+    for mag in mags:
+        dta = fam_data[mag]
+        idxs = dta['index']
+        subs = dta['subsection']
+        insts = dta['instance']
+        for idx, sub, inst in zip(idxs, subs, insts):
+            name = _join_name(sec='SI', dis='MA', sub=sub, idx=inst, dev=mag)
+            names[name] = idx
+
+    # Families
+    mags = quads[:]
+    mags.extend(_fams.families_sextupoles())
+    mags.extend(['B1B2-1', 'B1B2-2'])
+    for mag in mags:
+        name = _join_name(sec='SI', dis='MA', sub='Fam', dev=mag)
+        names[name] = fam_data[mag]['index']
+
+    return names

--- a/pymodels/SI_V25_01/families.py
+++ b/pymodels/SI_V25_01/families.py
@@ -1,0 +1,383 @@
+"""Element family definitions."""
+
+import pyaccel as _pyaccel
+
+
+_family_segmentation = {
+    'B1': 30, 'B2': 36, 'BC': 34,
+    'QFA': 1, 'QDA': 1,
+    'QFB': 1, 'QDB1': 1, 'QDB2': 1,
+    'QFP': 1, 'QDP1': 1, 'QDP2': 1,
+    'Q1': 1, 'Q2': 1, 'Q3': 1, 'Q4': 1,
+    'SDA0': 1, 'SDB0': 1, 'SDP0': 1,
+    'SDA1': 1, 'SDB1': 1, 'SDP1': 1,
+    'SDA2': 1, 'SDB2': 1, 'SDP2': 1,
+    'SDA3': 1, 'SDB3': 1, 'SDP3': 1,
+    'SFA0': 1, 'SFB0': 1, 'SFP0': 1,
+    'SFA1': 1, 'SFB1': 1, 'SFP1': 1,
+    'SFA2': 1, 'SFB2': 1, 'SFP2': 1,
+    'BPM': 1, 'DCCT': 1, 'ScrapH': 1, 'ScrapV': 1, 'GSL15': 1,
+    'GSL07': 1, 'GBPM': 1, 'BbBPkup': 1, 'BbBKckrH': 1, 'BbBKckrV': 1,
+    'BbBKckrL': 1, 'TuneShkrH': 1, 'TuneShkrV': 1, 'TunePkup': 1,
+    'FC1': 1, 'FC2': 1,
+    'QS': 1, 'CH': 1, 'CV': 1,
+    'SRFCav': 1, 'start': 1,
+    'InjDpKckr': 1, 'InjNLKckr': 1, 'PingH': 1, 'PingV': 1,
+    'APU22': 2, 'APU58': 2,
+    }
+
+
+family_mapping = {
+
+    'B1': 'dipole',
+    'B2': 'dipole',
+    'BC': 'dipole',
+    'B1B2-1': 'dipole',
+    'B1B2-2': 'dipole',
+
+    'QFA': 'quadrupole',
+    'QDA': 'quadrupole',
+    'QDB2': 'quadrupole',
+    'QFB': 'quadrupole',
+    'QDB1': 'quadrupole',
+    'QDP2': 'quadrupole',
+    'QFP': 'quadrupole',
+    'QDP1': 'quadrupole',
+    'Q1': 'quadrupole',
+    'Q2': 'quadrupole',
+    'Q3': 'quadrupole',
+    'Q4': 'quadrupole',
+
+    'SDA0': 'sextupole',
+    'SDB0': 'sextupole',
+    'SDP0': 'sextupole',
+    'SDA1': 'sextupole',
+    'SDB1': 'sextupole',
+    'SDP1': 'sextupole',
+    'SDA2': 'sextupole',
+    'SDB2': 'sextupole',
+    'SDP2': 'sextupole',
+    'SDA3': 'sextupole',
+    'SDB3': 'sextupole',
+    'SDP3': 'sextupole',
+    'SFA0': 'sextupole',
+    'SFB0': 'sextupole',
+    'SFP0': 'sextupole',
+    'SFA1': 'sextupole',
+    'SFB1': 'sextupole',
+    'SFP1': 'sextupole',
+    'SFA2': 'sextupole',
+    'SFB2': 'sextupole',
+    'SFP2': 'sextupole',
+
+    'InjNLKckr': 'pulsed_magnet',
+    'InjDpKckr': 'pulsed_magnet',
+    'PingH': 'pulsed_magnet',
+    'PingV': 'pulsed_magnet',
+
+    'BPM': 'bpm',
+    'DCCT': 'dcct_to_measure_beam_current',
+    'ScrapH': 'horizontal_scraper',
+    'ScrapV': 'vertical_scraper',
+    'GSL15': 'generic_stripline_(lambda/4)',
+    'GSL07': 'generic_stripline_(lambda/8)',
+    'GBPM': 'general_bpm',
+    'BbBPkup': 'bunch-by-bunch_pickup',
+    'BbBKckrH': 'horizontal_bunch-by-bunch_shaker',
+    'BbBKckrV': 'vertical_bunch-by-bunch_shaker',
+    'BbBKckrL': 'longitudinal_bunch-by-bunch_shaker',
+    'TuneShkrH': 'horizontal_tune_shaker',
+    'TuneShkrV': 'vertical_tune_shaker',
+    'TunePkup': 'tune_pickup',
+
+    'FC1': 'fast_corrector',
+    'FC2': 'fast_corrector',
+    'FCH': 'fast_horizontal_corrector',
+    'FCV': 'fast_vertical_corrector',
+
+    'CH': 'slow_horizontal_corrector',
+    'CV': 'slow_vertical_corrector',
+
+    'QS': 'skew_quadrupole',
+
+    'SRFCav': 'superconducting_rf_cavity',
+    'APU22': 'insertion_device',
+    'APU58': 'insertion_device',
+    }
+
+
+def families_dipoles():
+    """Return dipole families."""
+    return ['B1', 'B2', 'BC', ]
+
+
+def families_quadrupoles():
+    """Return quadrupole families."""
+    return ['QFA', 'QDA', 'QFB', 'QDB1', 'QDB2', 'QFP',
+            'QDP1', 'QDP2', 'Q1', 'Q2', 'Q3', 'Q4', ]
+
+
+def families_sextupoles():
+    """Return sextupole families."""
+    return ['SDA0', 'SDB0', 'SDP0',
+            'SDA1', 'SDB1', 'SDP1',
+            'SDA2', 'SDB2', 'SDP2',
+            'SDA3', 'SDB3', 'SDP3',
+            'SFA0', 'SFB0', 'SFP0',
+            'SFA1', 'SFB1', 'SFP1',
+            'SFA2', 'SFB2', 'SFP2', ]
+
+
+def families_horizontal_correctors():
+    """Return horizontal corrector families."""
+    return ['FCH', 'CH', ]
+
+
+def families_vertical_correctors():
+    """Return vertical corrector families."""
+    return ['FCV', 'CV', ]
+
+
+def families_skew_correctors():
+    """Return skew corrector families."""
+    return ['QS', ]
+
+
+def families_rf():
+    """Return RF families."""
+    return ['SRFCav', ]
+
+
+def families_pulsed_magnets():
+    """Return pulsed magnet families."""
+    return ['InjDpKckr', 'InjNLKckr', 'PingH', 'PingV', ]
+
+
+def families_di():
+    """Return diagnostics families."""
+    return ['BPM', 'DCCT', 'ScrapH', 'ScrapV', 'GSL15', 'GSL07',
+            'GBPM', 'BbBPkup', 'BbBKckrH', 'BbBKckrV', 'BbBKckL'
+            'TuneShkrH', 'TuneShkrV', 'TunePkup']
+
+
+def families_ids():
+    """Return insertion devices families."""
+    return ['APU22', 'APU58', ]
+
+
+def get_section_name_mapping(lattice):
+    """Return list with section name of each lattice element."""
+    lat = lattice[:]
+    section_map = ['' for i in range(len(lat))]
+
+    # find where the nomenclature starts counting and shift the lattice:
+    start = _pyaccel.lattice.find_indices(lat, 'fam_name', 'start')[0]
+    b1 = _pyaccel.lattice.find_indices(lat, 'fam_name', 'B1')
+    if b1[0] > start:
+        ind_shift = (b1[-1] + 1)  # Next element of last b1
+    else:
+        for i in b1[::-1]:  # except there is a b1 before start
+            if i < start:
+                ind_shift = i + 1
+                break
+    lat = _pyaccel.lattice.shift(lat, ind_shift)
+
+    # find indices important to define the change of the names of
+    # the subsections.
+    b1 = _pyaccel.lattice.find_indices(lat, 'fam_name', 'B1')
+    b1_nrsegs = len(b1)//40
+    b2 = _pyaccel.lattice.find_indices(lat, 'fam_name', 'B2')
+    # b2_nrsegs = len(b2)//40
+    bc = _pyaccel.lattice.find_indices(lat, 'fam_name', 'BC')
+    bpm = _pyaccel.lattice.find_indices(lat, 'fam_name', 'BPM')
+
+    # divide the ring in 20 sectors defined by the b1 dipoles:
+    Sects = []
+    ini = 0
+    for i in range(len(b1)//(2*b1_nrsegs)):
+        fim = b1[(i+1)*2*b1_nrsegs-1] + 1
+        Sects.append(list(range(ini, fim)))
+        ini = fim
+
+    # Names of the subsections:
+    sub_secs = ['M1', 'SX', 'M2', 'C1', 'C2', 'BC', 'C3', 'C4']
+    symm = ['SA', 'SB', 'SP', 'SB']
+
+    for i, sec in enumerate(Sects, 1):
+        # conditions that define change in subsection name:
+        # define changes to C1
+        sec_b1 = [x for x in b1 if sec[0] <= x <= sec[-1]]
+        relev_inds = [sec_b1[0]-1, sec_b1[-1]]
+        # define changes to C2 and C4:
+        sec_b2 = [x for x in b2 if sec[0] <= x <= sec[-1]]
+        relev_inds += [sec_b2[0]-1, sec_b2[-1]]
+        # define changes to BC and C3
+        sec_bc = [x for x in bc if sec[0] <= x <= sec[-1]]
+        relev_inds += [sec_bc[0]-1, sec_bc[-1]]
+        # define changes to SX and M2
+        sec_bpm = [x for x in bpm if sec[0] <= x <= sec[-1]]
+        relev_inds += [sec_bpm[0], sec_bpm[1]-1]
+        relev_inds.sort()
+        # fill the section_map variable
+        ref = 0
+        for j in sec:
+            section_map[(ind_shift+j) % len(lat)] = "{0:02d}".format(i)
+            section_map[(ind_shift+j) % len(lat)] += \
+                symm[(i-1) % len(symm)] if sub_secs[ref] == 'SX' else \
+                sub_secs[ref]
+            if j >= relev_inds[ref]:
+                ref += 1
+
+    return section_map
+
+
+def get_family_data(lattice):
+    """Get pyaccel lattice model index and segmentation for family names.
+
+    Keyword argument:
+    lattice -- lattice model
+
+    Returns dict.
+    """
+    latt_dict = _pyaccel.lattice.find_dict(lattice, 'fam_name')
+    section_map = get_section_name_mapping(lattice)
+
+    def get_idx(x):
+        return x[len(x)//2]
+    # get_idx = lambda x: x[0]
+
+    # fill the data dictionary with index info ######
+    data = {}
+    for key, idx in latt_dict.items():
+        nr = _family_segmentation.get(key)
+        if nr is None:
+            continue
+        # Create a list of lists for the indexes
+        data[key] = [idx[i*nr:(i+1)*nr] for i in range(len(idx)//nr)]
+
+    # ch - slow horizontal correctors
+    idx = []
+    fams = ['SDA0', 'SFB0', 'SFP0', 'SDA1', 'SDB1', 'SDP1',
+            'SFA2', 'SFB2', 'SFP2']
+    for fam in fams:
+        idx.extend(data[fam])
+    data['CH'] = sorted(idx, key=get_idx)
+
+    # cv - slow vertical correctors
+    idx = []
+    fams = ['SDA0', 'SFB0', 'SFP0', 'SDA1', 'SDB1', 'SDP1',
+            'SDA3', 'SDB3', 'SDP3', 'SFA2', 'SFB2', 'SFP2', 'CV']
+    for fam in fams:
+        if fam in {'SFA2', 'SFB2', 'SFP2'}:
+            # for these families there are skew only in C3 sections
+            idx.extend([i for i in data[fam] if 'C3' in section_map[i[0]]])
+        else:
+            idx.extend(data[fam])
+    data['CV'] = sorted(idx, key=get_idx)
+
+    # fch - fast horizontal correctors
+    data['FCH'] = sorted(data['FC1']+data['FC2'], key=get_idx)
+
+    # fcv - fast vertical correctors
+    data['FCV'] = sorted(data['FC1']+data['FC2'], key=get_idx)
+
+    # qs - skew quad correctors
+    idx = []
+    fams = ['SFA0', 'SDB0', 'SDP0', 'SDA2', 'SDB2',
+            'SDP2', 'SDA3', 'SDB3', 'SDP3', 'FC2']
+    for fam in fams:
+        if fam in {'SDA2', 'SDB2', 'SDP2'}:
+            # for these families there are skew only in C1 sections
+            idx.extend([i for i in data[fam] if 'C1' in section_map[i[0]]])
+        elif fam in {'SDA3', 'SDB3', 'SDP3'}:
+            # for these families there are skew only in C3 sections
+            idx.extend([i for i in data[fam] if 'C3' in section_map[i[0]]])
+        elif fam == 'FC2':
+            idx.extend([i for i in data[fam] if 'C2' in section_map[i[0]]])
+        else:
+            idx.extend(data[fam])
+    data['QS'] = sorted(idx, key=get_idx)
+
+    # quadrupoles knobs for optics correction
+    idx = []
+    fams = ['QFA', 'QDA', 'QDB2', 'QFB', 'QDB1', 'QDP2', 'QFP', 'QDP1',
+            'Q1', 'Q2', 'Q3', 'Q4']
+    for fam in fams:
+        idx.extend(data[fam])
+    data['QN'] = sorted(idx, key=get_idx)
+
+    # sbs - sextupoles knobs for optics correction
+    idx = []
+    fams = ['SDA0', 'SDB0', 'SDP0', 'SDA1', 'SDB1', 'SDP1', 'SDA2', 'SDB2',
+            'SDP2', 'SDA3', 'SDB3', 'SDP3', 'SFA0', 'SFB0', 'SFP0', 'SFA1',
+            'SFB1', 'SFP1', 'SFA2', 'SFB2', 'SFP2']
+    for fam in fams:
+        idx.extend(data[fam])
+    data['SN'] = sorted(idx, key=get_idx)
+
+    # Power Supply for B1 and B2 families
+    data['B1B2-1'] = sorted(data['B1']+data['B2'], key=get_idx)
+    data['B1B2-2'] = sorted(data['B1']+data['B2'], key=get_idx)
+
+    # all dipoles indices
+    data['BN'] = sorted(data['B1']+data['B2']+data['BC'], key=get_idx)
+
+    # PingH (in the model the same as InjDpKckr)
+    data['PingH'] = sorted(data['InjDpKckr'], key=get_idx)
+
+    # IDs
+    idx = []
+    fams = ['APU22', 'APU58', ]
+    for fam in fams:
+        idx.extend(data[fam])
+    data['ID'] = sorted(idx, key=get_idx)
+
+    # Girders
+    girder = get_girder_data(lattice)
+    if girder is not None:
+        data['girder'] = girder
+
+    def f(x):
+        return '{0:d}'.format(x)
+
+    # now organize the data dictionary:
+    new_data = dict()
+    for key, idx in data.items():
+        # find out the name of the section each element is installed
+        secs = [section_map[get_idx(i)] for i in idx]
+
+        # find out if there are more than one element per section and
+        # attribute a number to it
+        num = len(secs)*['']
+        if len(secs) > 1:
+            j = 1
+            num[0] = f(j) if secs[0] == secs[1] else ''
+            j = j+1 if secs[0] == secs[1] else 1
+            for i in range(1, len(secs)-1):
+                num[i] = f(j) if secs[i] == secs[i+1] or secs[i] == secs[i-1] \
+                    else ''
+                j = j+1 if secs[i] == secs[i+1] else 1
+            num[-1] = f(j)if (secs[-1] == secs[-2]) else ''
+
+        new_data[key] = {'index': idx, 'subsection': secs, 'instance': num}
+
+    # girders
+    return new_data
+
+
+def get_girder_data(lattice):
+    """Return girder data.
+
+    List of dicts, one for each girder, containing index of elements in that
+    girder.
+    """
+    gir = _pyaccel.lattice.find_indices(lattice, 'fam_name', 'girder')
+    if not gir:
+        return None
+    gir_ini = gir[0::2]
+    gir_end = gir[1::2]
+
+    data = []
+    for ini, end in zip(gir_ini, gir_end):
+        data.append(list(range(ini, end+1)))
+    return data

--- a/pymodels/SI_V25_01/lattice.py
+++ b/pymodels/SI_V25_01/lattice.py
@@ -1,0 +1,762 @@
+"""Lattice module.
+
+In this module the lattice of the corresponding accelerator is defined.
+"""
+
+import math as _math
+import numpy as _np
+
+import lnls as _lnls
+import mathphys as _mp
+from pyaccel import lattice as _pyacc_lat, elements as _pyacc_ele, \
+    accelerator as _pyacc_acc
+
+from . import segmented_models as _segmented_models
+
+default_optics_mode = 'S05.01'
+lattice_symmetry = 5
+harmonic_number = 864
+energy = 3e9  # [eV]
+
+
+def create_lattice(mode=default_optics_mode, simplified=False):
+    """Return lattice object."""
+    # -- selection of optics mode --
+    strengths = get_optics_mode(mode=mode)
+
+    # -- shortcut symbols --
+    marker = _pyacc_ele.marker
+    drift = _pyacc_ele.drift
+    sextupole = _pyacc_ele.sextupole
+    rfcavity = _pyacc_ele.rfcavity
+
+    # -- lattice markers --
+    m_accep_fam_name = 'calc_mom_accep'
+
+    dcircum = 518.3899 - 518.3960
+
+    # -- drifts --
+    LKK = drift('lkk', 1.9150)
+    LIA = drift('lia', 1.5179)
+    LIB = drift('lib', 1.0879)
+    LIP = drift('lip', 1.0879)
+    LPMU = drift('lpmu', 0.0600)
+    LPMD = drift('lpmd', 0.4929)
+    LID1 = drift('lid1', 1.83425)
+    LID2 = drift('lid2', 0.29965)
+    LID3 = drift('lid3', 1.8679)
+
+    L011 = drift('l011', 0.011)
+    L049 = drift('l049', 0.049)
+    L052 = drift('l052', 0.052)
+    L056 = drift('l056', 0.056)
+    L074 = drift('l074', 0.074)
+    L075 = drift('l075', 0.075)
+    L081 = drift('l081', 0.081)
+    L082 = drift('l082', 0.082)
+    L090 = drift('l090', 0.090)
+    L100 = drift('l100', 0.100)
+    L112 = drift('l112', 0.112)
+    L118 = drift('l118', 0.118)
+    L119 = drift('l119', 0.119)
+    L120 = drift('l120', 0.120)
+    L125 = drift('l125', 0.125)
+    L127 = drift('l127', 0.127)
+    L133 = drift('l133', 0.133)
+    L134 = drift('l134', 0.134)
+    L135 = drift('l135', 0.135)
+    L140 = drift('l140', 0.140)
+    L150 = drift('l150', 0.150)
+    L170 = drift('l170', 0.170)
+    L200 = drift('l200', 0.200)
+    L201 = drift('l201', 0.201)
+    L205 = drift('l205', 0.205)
+    L216 = drift('l216', 0.216)
+    L230 = drift('l230', 0.230)
+    L237 = drift('l237', 0.237)
+    L240 = drift('l240', 0.240)
+    L260 = drift('l260', 0.260)
+    L325 = drift('l325', 0.325)
+    L336 = drift('l336', 0.336)
+    L350 = drift('l350', 0.350)
+    L419 = drift('l419', 0.419)
+    L474 = drift('l474', 0.474)
+    L500 = drift('l500', 0.500)
+    L570 = drift('l570', 0.570)
+    L715 = drift('l715', 0.715)
+
+    # -- dipoles --
+    BC = _segmented_models.dipole_bc(m_accep_fam_name, simplified)
+    B1 = _segmented_models.dipole_b1(m_accep_fam_name, simplified)
+    B2 = _segmented_models.dipole_b2(m_accep_fam_name, simplified)
+
+    # -- quadrupoles --
+    QFA = _segmented_models.quadrupole_q20('QFA', strengths['QFA'], simplified)
+    QDA = _segmented_models.quadrupole_q14('QDA', strengths['QDA'], simplified)
+    QDB2 = _segmented_models.quadrupole_q14('QDB2', strengths['QDB2'],
+                                            simplified)
+    QFB = _segmented_models.quadrupole_q30('QFB', strengths['QFB'], simplified)
+    QDB1 = _segmented_models.quadrupole_q14('QDB1', strengths['QDB1'],
+                                            simplified)
+    QDP2 = _segmented_models.quadrupole_q14('QDP2', strengths['QDP2'],
+                                            simplified)
+    QFP = _segmented_models.quadrupole_q30('QFP', strengths['QFP'], simplified)
+    QDP1 = _segmented_models.quadrupole_q14('QDP1', strengths['QDP1'],
+                                            simplified)
+    Q1 = _segmented_models.quadrupole_q20('Q1', strengths['Q1'], simplified)
+    Q2 = _segmented_models.quadrupole_q20('Q2', strengths['Q2'], simplified)
+    Q3 = _segmented_models.quadrupole_q20('Q3', strengths['Q3'], simplified)
+    Q4 = _segmented_models.quadrupole_q20('Q4', strengths['Q4'], simplified)
+
+    # -- sextupoles --
+    SDA0 = sextupole('SDA0', 0.150, strengths['SDA0'])  # CH-CV
+    SDB0 = sextupole('SDB0', 0.150, strengths['SDB0'])  # CH-CV
+    SDP0 = sextupole('SDP0', 0.150, strengths['SDP0'])  # CH-CV
+    SDA1 = sextupole('SDA1', 0.150, strengths['SDA1'])  # QS
+    SDB1 = sextupole('SDB1', 0.150, strengths['SDB1'])  # QS
+    SDP1 = sextupole('SDP1', 0.150, strengths['SDP1'])  # QS
+    SDA2 = sextupole('SDA2', 0.150, strengths['SDA2'])  # CH-CV
+    SDB2 = sextupole('SDB2', 0.150, strengths['SDB2'])  # CH-CV
+    SDP2 = sextupole('SDP2', 0.150, strengths['SDP2'])  # CH-CV
+    SDA3 = sextupole('SDA3', 0.150, strengths['SDA3'])  # --
+    SDB3 = sextupole('SDB3', 0.150, strengths['SDB3'])  # --
+    SDP3 = sextupole('SDP3', 0.150, strengths['SDP3'])  # --
+    SFA0 = sextupole('SFA0', 0.150, strengths['SFA0'])  # CV
+    SFB0 = sextupole('SFB0', 0.150, strengths['SFB0'])  # CV
+    SFP0 = sextupole('SFP0', 0.150, strengths['SFP0'])  # CV
+    SFA1 = sextupole('SFA1', 0.150, strengths['SFA1'])  # QS
+    SFB1 = sextupole('SFB1', 0.150, strengths['SFB1'])  # QS
+    SFP1 = sextupole('SFP1', 0.150, strengths['SFP1'])  # QS
+    SFA2 = sextupole('SFA2', 0.150, strengths['SFA2'])  # CH
+    SFB2 = sextupole('SFB2', 0.150, strengths['SFB2'])  # CH-CV
+    SFP2 = sextupole('SFP2', 0.150, strengths['SFP2'])  # CH-CV
+
+    # -- slow vertical corrector --
+    CV = sextupole('CV', 0.150, 0.0)  # same model as BO correctors
+
+    # -- pulsed magnets --
+    InjDpKckr = sextupole('InjDpKckr', 0.400, S=0.0)  # injection kicker
+    InjNLKckr = sextupole('InjNLKckr', 0.450, S=0.0)  # pulsed multipole magnet
+    PingV = marker('PingV')  # Vertical Pinger
+
+    # -- fast correctors --
+    # 60 magnets: normal quad poles (CH+CV and CH+CV+QS):
+    FC1 = sextupole('FC1', 0.084, S=0.0)
+    # 20 magnets: skew quad poles (CH+CV and CH+CV+QS):
+    FC2 = sextupole('FC2', 0.082, S=0.0)
+
+    # -- rf cavities --
+    RFC = rfcavity('SRFCav', 0, 3.0e6, 500e6)
+    HCav = marker('H3Cav')
+
+    # -- insertion devices --
+    APU22H = drift('APU22', 1.300/2)
+    APU58H = drift('APU58', 1.300/2)
+
+    # -- lattice markers --
+    START = marker('start')  # start of the model
+    END = marker('end')  # end of the model
+    MIA = marker('mia')  # center of long straight sections (even-numbered)
+    MIB = marker('mib')  # center of short straight sections (odd-numbered)
+    MIP = marker('mip')  # center of short straight sections (odd-numbered)
+    # marker used to delimitate girders.
+    # one marker at begin and another at end of girder:
+    GIR = marker('girder')
+    # marker for the extremities of IDs in long straight sections
+    MIDA = marker('id_enda')
+    # marker for the extremities of IDs in short straight sections
+    MIDB = marker('id_endb')
+    # marker for the extremities of IDs in short straight sections
+    MIDP = marker('id_endp')
+    # end of injection septum
+    InjSeptF = marker('InjSeptF')
+
+    # --- Diagnostic Components ---
+    BPM = marker('BPM')
+    DCCT = marker('DCCT')  # dcct to measure beam current
+    ScrapH = marker('ScrapH')  # horizontal scraper
+    ScrapV = marker('ScrapV')  # vertical scraper
+    GSL15 = marker('GSL15')  # Generic Stripline (lambda/4)
+    GSL07 = marker('GSL07')  # Generic Stripline (lambda/8)
+    GBPM = marker('GBPM')  # General BPM
+    BbBPkup = marker('BbBPkup')  # Bunch-by-Bunch Pickup
+    BbBKckrH = marker('BbBKckrH')  # Horizontal Bunch-by-Bunch Shaker
+    BbBKckrV = marker('BbBKckrV')  # Vertical Bunch-by-Bunch Shaker
+
+    BbBKckL = marker('BbBKckrL')  # Longitudinal Bunch-by-Bunch Shaker
+
+    TuneShkrH = marker('TuneShkrH')  # Horizontal Tune Shaker
+    TuneShkrV = marker('TuneShkrV')  # Vertical Tune Shaker
+    TunePkup = marker('TunePkup')  # Tune Pickup
+
+    # -- transport lines --
+    M1A = [
+        L134, QDA, L150, SDA0, GIR, L074, GIR, FC1, L082, QFA, L150, SFA0,
+        L135, BPM, GIR]  # high beta xxM1 girder (with fasc corrector)
+    M1B = [
+        L134, QDB1, L150, SDB0, GIR, L240, GIR, QFB, L150, SFB0, L049, FC1,
+        L052, QDB2, L140, BPM, GIR]  # low beta xxM1 girder
+    M1P = [
+        L134, QDP1, L150, SDP0, GIR, L240, GIR, QFP, L150, SFP0, L049, FC1,
+        L052, QDP2, L140, BPM, GIR]  # low beta xxM1 girder
+    M2A = M1A[::-1]  # high beta xxM2 girder (with fast correctors)
+    M2B = M1B[::-1]  # low beta xxM2 girder
+    M2P = M1P[::-1]  # low beta xxM2 girder
+
+    M1B_BbBPkup = [
+        L134, QDB1, L150, SDB0, GIR, L120, BbBPkup, L120, GIR, QFB, L150, SFB0,
+        L049, FC1, L052, QDB2, L140, BPM, GIR]
+
+    # SS_S01 = IDA_INJ
+    # SS_S05 = IDA_ScrapH
+    # SS_S09 = IDA_APU22
+    # SS_S13 = IDA_BbBKckrH
+    # SS_S17 = IDA17
+
+    L500p = drift('L500p', 0.5000 + dcircum/5/2)
+    LKKp = drift('lkkp', 1.9150 + dcircum/5/2)
+
+    IDA = [
+        L500, LIA, L500, MIDA, L500, L500, MIA, L500, L500, MIDA, L500, LIA,
+        L500]  # high beta ID straight section
+    IDA_INJ = [
+        L500, TuneShkrH, LIA, L419, InjSeptF, L081, L500, L500p, END, START,
+        MIA, LKKp, InjDpKckr, LPMU, ScrapV, L100, ScrapV, L100,
+        InjNLKckr, LPMD]  # high beta INJ straight section and Scrapers
+    IDA_BbBKckrH = [
+        L500, BbBKckrH, LIA, L500, MIDA, L500, L500p, MIA, L500p, L500, MIDA,
+        L500, LIA, L500]  # high beta ID straight section
+    IDA_ScrapH = [
+        L500, LIA, L500, MIDA, L500, L500p, MIA, L500p, L500, MIDA, L500, ScrapH,
+        LIA, L500]  # high beta ID straight section
+    IDA17 = [
+        L500, LIA, L500, MIDA, L500, L500p, MIA, L500p, L500, MIDA, L500,
+        BbBKckrH, LIA, L500]  # high beta ID straight section
+
+    IDB = [
+        L500, LIB, L500, MIDB, L500, L500, MIB, L500, L500, MIDB, L500, LIB,
+        L500]  # low beta ID straight section
+    IDB_GSL07 = [
+        L500, GSL07, LIB, L500, MIDB, L500, L500, MIB, L500, L500, MIDB, L500,
+        LIB, L500]  # low beta ID straight section
+    IDB_TunePkup = [
+        L500, LIB, L500, MIDB, L500, L500, MIB, L500, L500, MIDB, L500,
+        TunePkup, LIB, L500]  # low beta ID straight section
+    IDB02 = [
+        L500, LIB, L500, MIDB, L500, L500, MIB, L500, L500, MIDB, L500, HCav,
+        LIB, L500]  # low beta ID straight section
+    IDB16 = [
+        L500, LIB, L500, MIDB, L500, L500, MIB, L500, L500, MIDB, L500,
+        BbBKckL, LIB, L500]  # low beta ID straight section
+
+    IDP = [
+        L500, LIP, L500, MIDP, L500, L500, MIP, L500, L500, MIDP, L500, LIP,
+        L500]  # low beta ID straight section
+    IDP_CAV = [
+        L500, LIP, L500, L500, L500, MIP, RFC, L500, L500, L500,
+        LIP, L500]  # low beta RF cavity straight section
+    IDP_GSL15 = [
+        L500, GSL15, LIP, L500, MIDP, L500, L500, MIP, L500, L500, MIDP, L500,
+        LIP, L500]  # low beta ID straight section
+
+    # arc sector in between B1-B2 (high beta odd-numbered straight sections):
+    C1A = [
+        GIR, L474, GIR, SDA1, L170, Q1, L135, BPM, L125, SFA1, L230, Q2, L170,
+        SDA2, GIR, L205, GIR, BPM, L011]
+    # arc sector in between B1-B2 (low beta  even-numbered straight sections):
+    C1B = [
+        GIR, L474, GIR, SDB1, L170, Q1, L135, BPM, L125, SFB1, L230, Q2,
+        L170, SDB2, GIR, L205, GIR, BPM, L011]
+    # arc sector in between B1-B2 (low beta even-numbered straight sections):
+    C1P = [
+        GIR, L474, GIR, SDP1, L170, Q1, L135, BPM, L125, SFP1, L230, Q2, L170,
+        SDP2, GIR, L205, GIR, BPM, L011]
+
+    # arc sector in between B2-BC (high beta odd-numbered straight sections):
+    C2A = [
+        GIR, L336, GIR, SDA3, L170, Q3, L230, SFA2, L260, Q4, L200, CV, GIR,
+        L201, GIR, FC2, L119, BPM, L075]
+    # arc sector in between B2-BC (low beta even-numbered straight sections):
+    C2B = [
+        GIR, L336, GIR, SDB3, L170, Q3, L230, SFB2, L260, Q4, L200, CV, GIR,
+        L201, GIR, FC2, L119, BPM, L075]
+    # arc sector in between B2-BC (low beta even-numbered straight sections):
+    C2P = [
+        GIR, L336, GIR, SDP3, L170, Q3, L230, SFP2, L260, Q4, L200, CV, GIR,
+        L201, GIR, FC2, L119, BPM, L075]
+
+    # arc sector in between BC-B2 (high beta odd-numbered straight sections):
+    C3A = [
+        GIR, L715, GIR, L112, Q4, L133, BPM, L127, SFA2, L056, FC1, L090, Q3,
+        L170, SDA3, GIR, L325, GIR, BPM, L011]
+    # arc sector in between BC-B2 (low beta even-numbered straight sections):
+    C3B = [
+        GIR, L715, GIR, L112, Q4, L133, BPM, L127, SFB2, L056, FC1, L090, Q3,
+        L170, SDB3, GIR, L325, GIR, BPM, L011]
+    # arc sector in between BC-B2 (low beta even-numbered straight sections):
+    C3P = [
+        GIR, L715, GIR, L112, Q4, L133, BPM, L127, SFP2, L056, FC1, L090, Q3,
+        L170, SDP3, GIR, L325, GIR, BPM, L011]
+
+    # arc sector in between B2-B1 (high beta odd-numbered straight sections):
+    C4A = [
+        GIR, L216, GIR, SDA2, L170, Q2, L230, SFA1, L125, BPM, L135, Q1, L170,
+        SDA1, GIR, L474, GIR]
+    # arc sector in between B2-B1 (high beta odd-numbered straight sections):
+    C4A_BbBKckrV = [
+        GIR, L216, GIR, SDA2, L170, Q2, L230, SFA1, L125, BPM, L135, Q1, L170,
+        SDA1, L237, BbBKckrV, GIR, L237, GIR]
+
+    # arc sector in between B2-B1 (low beta even-numbered straight sections):
+    C4B = [
+        GIR, L216, GIR, SDB2, L170, Q2, L230, SFB1, L125, BPM, L135, Q1, L170,
+        SDB1, GIR, L474, GIR]
+    # arc sector in between B2-B1 (low beta even-numbered straight sections):
+    C4B_GBPM = [
+        GIR, L216, GIR, SDB2, L170, Q2, L230, SFB1, L125, BPM, L135, Q1, L170,
+        SDB1, GBPM, GIR, L474, GIR]
+    # arc sector in between B2-B1 (low beta even-numbered straight sections):
+    C4B_DCCT = [
+        GIR, L216, GIR, SDB2, L170, Q2, L230, SFB1, L125, BPM, L135, Q1, L170,
+        SDB1, L237, DCCT, GIR, L237, GIR]
+    # arc sector in between B2-B1 (low beta even-numbered straight sections):
+    C4B_TunePkup = [
+        GIR, L216, GIR, SDB2, L170, Q2, L230, SFB1, L125, BPM, L135, Q1, L170,
+        SDB1, L237, TunePkup, GIR, L237, GIR]
+    # arc sector in between B2-B1 (low beta even-numbered straight sections)
+    C4B_PingV = [
+        GIR, L216, GIR, SDB2, L170, Q2, L230, SFB1, L125, BPM, L135, Q1, L170,
+        SDB1, L237, PingV, GIR, L237, GIR]
+
+    # arc sector in between B2-B1 (low beta even-numbered straight sections):
+    C4P = [
+        GIR, L216, GIR, SDP2, L170, Q2, L230, SFP1, L125, BPM, L135, Q1, L170,
+        SDP1, GIR, L474, GIR]
+    # arc sector in between B2-B1 (low beta even-numbered straight sections):
+    C4P_DCCT = [
+        GIR, L216, GIR, SDP2, L170, Q2, L230, SFP1, L125, BPM, L135, Q1, L170,
+        SDP1, L237, DCCT, GIR, L237, GIR]
+    # arc sector in between B2-B1 (low beta even-numbered straight sections):
+    C4P_TuneShkrV = [
+        GIR, L216, GIR, SDP2, L170, Q2, L230, SFP1, L125, BPM, L135, Q1, L170,
+        SDP1, L237, TuneShkrV, GIR, L237, GIR]
+
+    # -- insertion devices --
+
+    IDA_APU22 = [
+        L500, LID3, L500p,
+        MIDA, APU22H, MIA, APU22H, MIDA,
+        L500p, LID3, L500]  # high beta ID straight section
+    IDP_APU22 = [
+        L500, LIP, L500, L350,
+        MIDP, APU22H, MIP, APU22H, MIDP,
+        L350, L500, LIP, L500]  # low beta ID straight section
+    IDB_APU22 = [
+        L500, LIB, L500, L350,
+        MIDB, APU22H, MIB, APU22H, MIDB,
+        L350, L500, LIB, L500]  # low beta ID straight section
+    IDP_APU58 = [
+        L500, LIP, L500, L350,
+        MIDP, APU58H, MIP, APU58H, MIDP,
+        L350, L500, LIP, L500]  # low beta ID straight section
+    # -- girders --
+
+    # straight sections
+    SS_S01 = IDA_INJ
+    SS_S02 = IDB02
+    SS_S03 = IDP_CAV
+    SS_S04 = IDB
+    SS_S05 = IDA_ScrapH
+    SS_S06 = IDB_APU22
+    SS_S07 = IDP_APU22
+    SS_S08 = IDB_APU22
+    SS_S09 = IDA_APU22
+    SS_S10 = IDB
+    SS_S11 = IDP_APU58
+    SS_S12 = IDB
+    SS_S13 = IDA_BbBKckrH
+    SS_S14 = IDB
+    SS_S15 = IDP
+    SS_S16 = IDB16
+    SS_S17 = IDA17
+    SS_S18 = IDB_TunePkup
+    SS_S19 = IDP_GSL15
+    SS_S20 = IDB_GSL07
+
+    # down and upstream straight sections
+    M1_S01 = M1A
+    M2_S01 = M2A
+    M1_S02 = M1B
+    M2_S02 = M2B
+    M1_S03 = M1P
+    M2_S03 = M2P
+    M1_S04 = M1B
+    M2_S04 = M2B
+    M1_S05 = M1A
+    M2_S05 = M2A
+    M1_S06 = M1B
+    M2_S06 = M2B
+    M1_S07 = M1P
+    M2_S07 = M2P
+    M1_S08 = M1B
+    M2_S08 = M2B
+    M1_S09 = M1A
+    M2_S09 = M2A
+    M1_S10 = M1B
+    M2_S10 = M2B
+    M1_S11 = M1P
+    M2_S11 = M2P
+    M1_S12 = M1B_BbBPkup
+    M2_S12 = M2B
+    M1_S13 = M1A
+    M2_S13 = M2A
+    M1_S14 = M1B
+    M2_S14 = M2B
+    M1_S15 = M1P
+    M2_S15 = M2P
+    M1_S16 = M1B
+    M2_S16 = M2B
+    M1_S17 = M1A
+    M2_S17 = M2A
+    M1_S18 = M1B
+    M2_S18 = M2B
+    M1_S19 = M1P
+    M2_S19 = M2P
+    M1_S20 = M1B
+    M2_S20 = M2B
+
+    # dispersive arcs
+    C1_S01 = C1A
+    C2_S01 = C2A
+    C3_S01 = C3B
+    C4_S01 = C4B
+    C1_S02 = C1B
+    C2_S02 = C2B
+    C3_S02 = C3P
+    C4_S02 = C4P
+    C1_S03 = C1P
+    C2_S03 = C2P
+    C3_S03 = C3B
+    C4_S03 = C4B
+    C1_S04 = C1B
+    C2_S04 = C2B
+    C3_S04 = C3A
+    C4_S04 = C4A
+    C1_S05 = C1A
+    C2_S05 = C2A
+    C3_S05 = C3B
+    C4_S05 = C4B
+    C1_S06 = C1B
+    C2_S06 = C2B
+    C3_S06 = C3P
+    C4_S06 = C4P
+    C1_S07 = C1P
+    C2_S07 = C2P
+    C3_S07 = C3B
+    C4_S07 = C4B
+    C1_S08 = C1B
+    C2_S08 = C2B
+    C3_S08 = C3A
+    C4_S08 = C4A
+    C1_S09 = C1A
+    C2_S09 = C2A
+    C3_S09 = C3B
+    C4_S09 = C4B
+    C1_S10 = C1B
+    C2_S10 = C2B
+    C3_S10 = C3P
+    C4_S10 = C4P
+    C1_S11 = C1P
+    C2_S11 = C2P
+    C3_S11 = C3B
+    C4_S11 = C4B
+    C1_S12 = C1B
+    C2_S12 = C2B
+    C3_S12 = C3A
+    C4_S12 = C4A
+    C1_S13 = C1A
+    C2_S13 = C2A
+    C3_S13 = C3B
+    C4_S13 = C4B_DCCT
+    C1_S14 = C1B
+    C2_S14 = C2B
+    C3_S14 = C3P
+    C4_S14 = C4P_DCCT
+    C1_S15 = C1P
+    C2_S15 = C2P
+    C3_S15 = C3B
+    C4_S15 = C4B_GBPM
+    C1_S16 = C1B
+    C2_S16 = C2B
+    C3_S16 = C3A
+    C4_S16 = C4A_BbBKckrV
+    C1_S17 = C1A
+    C2_S17 = C2A
+    C3_S17 = C3B
+    C4_S17 = C4B_TunePkup
+    C1_S18 = C1B
+    C2_S18 = C2B
+    C3_S18 = C3P
+    C4_S18 = C4P_TuneShkrV
+    C1_S19 = C1P
+    C2_S19 = C2P
+    C3_S19 = C3B
+    C4_S19 = C4B_PingV
+    C1_S20 = C1B
+    C2_S20 = C2B
+    C3_S20 = C3A
+    C4_S20 = C4A
+
+    # SECTORS # 01..20
+    S01 = [
+        M1_S01, SS_S01, M2_S01, B1, C1_S01, B2, C2_S01, BC,
+        C3_S01, B2, C4_S01, B1]
+    S02 = [
+        M1_S02, SS_S02, M2_S02, B1, C1_S02, B2, C2_S02, BC,
+        C3_S02, B2, C4_S02, B1]
+    S03 = [
+        M1_S03, SS_S03, M2_S03, B1, C1_S03, B2, C2_S03, BC,
+        C3_S03, B2, C4_S03, B1]
+    S04 = [
+        M1_S04, SS_S04, M2_S04, B1, C1_S04, B2, C2_S04, BC,
+        C3_S04, B2, C4_S04, B1]
+    S05 = [
+        M1_S05, SS_S05, M2_S05, B1, C1_S05, B2, C2_S05, BC,
+        C3_S05, B2, C4_S05, B1]
+    S06 = [
+        M1_S06, SS_S06, M2_S06, B1, C1_S06, B2, C2_S06, BC,
+        C3_S06, B2, C4_S06, B1]
+    S07 = [
+        M1_S07, SS_S07, M2_S07, B1, C1_S07, B2, C2_S07, BC,
+        C3_S07, B2, C4_S07, B1]
+    S08 = [
+        M1_S08, SS_S08, M2_S08, B1, C1_S08, B2, C2_S08, BC,
+        C3_S08, B2, C4_S08, B1]
+    S09 = [
+        M1_S09, SS_S09, M2_S09, B1, C1_S09, B2, C2_S09, BC,
+        C3_S09, B2, C4_S09, B1]
+    S10 = [
+        M1_S10, SS_S10, M2_S10, B1, C1_S10, B2, C2_S10, BC,
+        C3_S10, B2, C4_S10, B1]
+    S11 = [
+        M1_S11, SS_S11, M2_S11, B1, C1_S11, B2, C2_S11, BC,
+        C3_S11, B2, C4_S11, B1]
+    S12 = [
+        M1_S12, SS_S12, M2_S12, B1, C1_S12, B2, C2_S12, BC,
+        C3_S12, B2, C4_S12, B1]
+    S13 = [
+        M1_S13, SS_S13, M2_S13, B1, C1_S13, B2, C2_S13, BC,
+        C3_S13, B2, C4_S13, B1]
+    S14 = [
+        M1_S14, SS_S14, M2_S14, B1, C1_S14, B2, C2_S14, BC,
+        C3_S14, B2, C4_S14, B1]
+    S15 = [
+        M1_S15, SS_S15, M2_S15, B1, C1_S15, B2, C2_S15, BC,
+        C3_S15, B2, C4_S15, B1]
+    S16 = [
+        M1_S16, SS_S16, M2_S16, B1, C1_S16, B2, C2_S16, BC,
+        C3_S16, B2, C4_S16, B1]
+    S17 = [
+        M1_S17, SS_S17, M2_S17, B1, C1_S17, B2, C2_S17, BC,
+        C3_S17, B2, C4_S17, B1]
+    S18 = [
+        M1_S18, SS_S18, M2_S18, B1, C1_S18, B2, C2_S18, BC,
+        C3_S18, B2, C4_S18, B1]
+    S19 = [
+        M1_S19, SS_S19, M2_S19, B1, C1_S19, B2, C2_S19, BC,
+        C3_S19, B2, C4_S19, B1]
+    S20 = [
+        M1_S20, SS_S20, M2_S20, B1, C1_S20, B2, C2_S20, BC,
+        C3_S20, B2, C4_S20, B1]
+
+    anel = [S01, S02, S03, S04, S05, S06, S07, S08, S09, S10,
+            S11, S12, S13, S14, S15, S16, S17, S18, S19, S20]
+    anel = _lnls.utils.flatten(anel)
+
+    the_ring = _pyacc_lat.build(anel)
+
+    # -- shifts model to marker 'start'
+    idx = _pyacc_lat.find_indices(the_ring, 'fam_name', 'start')
+    the_ring = _pyacc_lat.shift(the_ring, idx[0])
+
+    # -- sets rf frequency
+    set_rf_frequency(the_ring)
+
+    # -- sets number of integration steps
+    set_num_integ_steps(the_ring)
+
+    # -- define vacuum chamber for all elements
+    the_ring = set_vacuum_chamber(the_ring)
+
+    return the_ring
+
+
+def set_rf_frequency(the_ring):
+    """Set RF frequency of the lattice."""
+    circumference = _pyacc_lat.length(the_ring)
+    # _, beam_velocity, _, _, _ = _mp.beam_optics.beam_rigidity(energy=energy)
+    # velocity = beam_velocity
+    velocity = _mp.constants.light_speed
+    rev_frequency = velocity / circumference
+    rf_frequency = harmonic_number * rev_frequency
+    idx = _pyacc_lat.find_indices(the_ring, 'fam_name', 'SRFCav')
+    for i in idx:
+        the_ring[i].frequency = rf_frequency
+
+
+def set_num_integ_steps(the_ring):
+    """Set number of integration steps in each lattice element."""
+    len_bends = 0.050
+    len_quads = 0.015
+    len_sexts = 0.015
+    for i in range(len(the_ring)):
+        if the_ring[i].angle:
+            nr_steps = int(_math.ceil(the_ring[i].length/len_bends))
+            the_ring[i].nr_steps = nr_steps
+        elif the_ring[i].polynom_b[2]:
+            nr_steps = int(_math.ceil(the_ring[i].length/len_sexts))
+            the_ring[i].nr_steps = nr_steps
+        elif the_ring[i].polynom_b[1] or the_ring[i].fam_name in \
+                ['FC1', 'FC2', 'InjDpKckr', 'InjNLKckr']:
+            nr_steps = int(_math.ceil(the_ring[i].length/len_quads))
+            the_ring[i].nr_steps = nr_steps
+
+
+def set_vacuum_chamber(the_ring, mode=default_optics_mode):
+    """Set vacuum chamber for all elements."""
+    # vchamber = [hmin, hmax, vmin, vmax] (meter)
+    other_vchamber = [-0.012, 0.012, -0.012, 0.012]
+    idb_vchamber = [-0.004, 0.004, -0.00225, 0.00225]
+    ida_vchamber = [-0.012, 0.012, -0.004, 0.004]
+    bc_hfield_vchamber = [-0.004, 0.004, -0.004, 0.004]
+    inj_vchamber = [-0.030, 0.012, -0.012, 0.012]
+    idp_vchamber = idb_vchamber if mode.startswith('S05') else ida_vchamber
+
+    # Set ordinary Vacuum Chamber
+    for i in range(len(the_ring)):
+        e = the_ring[i]
+        e.hmin, e.hmax, e.vmin, e.vmax = other_vchamber
+
+    # Shift the ring so that lattice does not begin between id markers
+    bpm = _pyacc_lat.find_indices(the_ring, 'fam_name', 'BPM')
+    the_ring = _pyacc_lat.shift(the_ring, bpm[0])
+
+    # NOTE: Insertion devices vchamber temporarily off
+
+    # # Set in-vacuum ids vacuum chamber
+    # idb = _pyacc_lat.find_indices(the_ring, 'fam_name', 'id_endb')
+    # print(idb)
+    # idb_list = []
+    # for i in range(len(idb)//2):
+    #     idb_list.extend(range(idb[2*i], idb[2*i+1]+1))
+    # print(idb_list)
+    # for i in idb_list:
+    #     e = the_ring[i]
+    #     e.hmin, e.hmax, e.vmin, e.vmax = idb_vchamber
+
+    # # Set other ids vacuum chamber
+    # ida = _pyacc_lat.find_indices(the_ring, 'fam_name', 'id_enda')
+    # ida_list = []
+    # for i in range(len(ida)//2):
+    #     ida_list.extend(range(ida[2*i], ida[2*i+1]+1))
+    # for i in ida_list:
+    #     e = the_ring[i]
+    #     e.hmin, e.hmax, e.vmin, e.vmax = ida_vchamber
+
+    # # Set other ids vacuum chamber
+    # idp = _pyacc_lat.find_indices(the_ring, 'fam_name', 'id_endp')
+    # idp_list = []
+    # for i in range(len(idp)//2):
+    #     idp_list.extend(range(idp[2*i], idp[2*i+1]+1))
+    # for i in idp_list:
+    #     e = the_ring[i]
+    #     e.hmin, e.hmax, e.vmin, e.vmax = idp_vchamber
+
+    # Shift the ring back.
+    the_ring = _pyacc_lat.shift(the_ring, len(the_ring)-bpm[0])
+
+    # Set injection vacuum chamber
+    sept_in = _pyacc_lat.find_indices(the_ring, 'fam_name', 'InjSeptF')[-1]
+    kick_in = _pyacc_lat.find_indices(the_ring, 'fam_name', 'InjDpKckr')[0]
+    inj_list = list(range(sept_in, len(the_ring))) + list(range(kick_in+1))
+    for i in inj_list:
+        e = the_ring[i]
+        e.hmin, e.hmax, e.vmin, e.vmax = inj_vchamber
+
+    # Set high field BC vacuum chamber
+    # NOTE: segments with bending radius smaller than this value
+    # are supposed to have reduced vacuum chamber. This should be
+    # replaced by specification of the vacuum chamber
+    rho0 = 5.0  # [m]
+    indices = _pyacc_lat.find_indices(the_ring, 'fam_name', 'BC')
+    for i in indices:
+        e = the_ring[i]
+        ang, lng = e.angle, e.length
+        rho = lng/ang
+        if rho < rho0:
+            e.hmin, e.hmax, e.vmin, e.vmax = bc_hfield_vchamber
+    indices = _pyacc_lat.find_indices(the_ring, 'fam_name', 'mc')
+    for i in indices:
+        e = the_ring[i]
+        e.hmin, e.hmax, e.vmin, e.vmax = bc_hfield_vchamber
+        e = the_ring[i + 1]
+        e.hmin, e.hmax, e.vmin, e.vmax = bc_hfield_vchamber
+
+    return the_ring
+
+
+def get_optics_mode(mode=default_optics_mode):
+    """Return magnet strengths for a given optics mode."""
+    mode, version = mode.split('.')
+
+    if mode == 'S05':
+        if version == '01':
+            strengths = {
+                #  QUADRUPOLES
+                #  ===========
+                'Q1': +2.818370601288,
+                'Q2': +4.340329381668,
+                'Q3': +3.218430939674,
+                'Q4': +3.950686823494,
+
+                # NOTE: these values need updating after optics resimetrization with MAD
+                'QDA':  -1.619540412181686,
+                'QFA':  +3.5731777226094446,
+                'QFB':  +4.115082809275146,
+                'QFP':  +4.115082809275146,
+                'QDB1': -2.00677456404202,
+                'QDB2': -3.420574744932221,
+                'QDP1': -2.00677456404202,
+                'QDP2': -3.420574744932221,
+
+                #  SEXTUPOLES
+                #  ===========
+                'SDA0': -80.8337,
+                'SDB0': -64.9422,
+                'SDP0': -64.9422,
+                'SFA0': +52.5696,
+                'SFB0': +73.7401,
+                'SFP0': +73.7401,
+
+                'SDA1': -163.0062328090773,
+                'SDA2': -88.88255991288263,
+                'SDA3': -139.94153649641189,
+                'SFA1': +191.76738248436368,
+                'SFA2': +150.74610044115283,
+                'SDB1': -141.68687364847958,
+                'SDB2': -122.31573949946443,
+                'SDB3': -173.8347917755106,
+                'SFB1': +227.7404567527413,
+                'SFB2': +197.7495405020359,
+                'SDP1': -142.31415019209263,
+                'SDP2': -122.28457189976633,
+                'SDP3': -174.1745194336169,
+                'SFP1': +229.17648360831797,
+                'SFP2': +198.4525009917773,
+            }
+        else:
+            raise _pyacc_acc.AcceleratorException('Version not Implemented')
+    else:
+        raise _pyacc_acc.AcceleratorException('Mode not Implemented.')
+
+    return strengths

--- a/pymodels/SI_V25_01/segmented_models.py
+++ b/pymodels/SI_V25_01/segmented_models.py
@@ -1,0 +1,435 @@
+"""Segmented models of the lattice."""
+
+import math as _math
+import numpy as _np
+import pyaccel as _pyaccel
+
+
+def dipole_bc(m_accep_fam_name, simplified=False):
+    """Segmented BC dipole model."""
+    segtypes = {
+        'BC': ('BC', _pyaccel.elements.rbend),
+        'BC_EDGE': ('BC_EDGE', _pyaccel.elements.marker),
+        'mc': ('mc', _pyaccel.elements.marker),
+        'm_accep': (m_accep_fam_name, _pyaccel.elements.marker),
+    }
+
+    # Average Dipole Model for BC
+    # =============================================
+    # date: 2019-06-27
+    # Based on multipole expansion around average segmented model trajectory calculated
+    # from fieldmap analysis of measurement data
+    # folder = si-dipoles-bc/model-13/analysis/hallprobe/production/x0-0p079mm-reftraj
+    # init_rx =  79 um
+    # ref_rx  = 7.7030 mm (average model trajectory)
+    # goal_tunes = [49.096188917357331, 14.151971558423915];
+    # goal_chrom = [2.549478494984214, 2.527086095938103];
+
+    monomials = [0, 1, 2, 3, 4, 5, 6, 7, 8, 10]
+    segmodel = [
+     #         len[m]  angle[deg]  PolyB(n=0)   PolyB(n=1)   PolyB(n=2)   PolyB(n=3)   PolyB(n=4)   PolyB(n=5)   PolyB(n=6)   PolyB(n=7)   PolyB(n=8)   PolyB(n=10)
+        ['BC', 0.00100, 0.01877, -1.4741e-05, -3.2459e-03, -2.5934e+01, +2.2655e+02, -4.2041e+05, -1.9362e+06, -8.8515e+08, +1.8066e+10, -4.1927e+13, +1.8535e+17],
+        ['BC', 0.00400, 0.07328, -3.5868e-06, -8.0872e-03, -2.3947e+01, +1.9896e+02, -3.8312e+05, -1.5555e+06, -8.7538e+08, +1.5588e+10, -3.4411e+13, +1.5036e+17],
+        ['BC', 0.00500, 0.08149, -1.5878e-06, -2.2156e-02, -1.6636e+01, +9.5225e+01, -2.4803e+05, -2.8667e+05, -6.2015e+08, +5.9788e+09, -1.1795e+13, +5.3967e+16],
+        ['BC', 0.00500, 0.06914, -2.2515e-06, -2.6794e-02, -9.9744e+00, +4.0910e+01, -1.2934e+05, -1.8459e+04, +6.5912e+06, +1.8432e+09, -3.7282e+12, +1.5831e+16],
+        ['BC', 0.00500, 0.05972, +2.4800e-07, -2.6704e-02, -7.1238e+00, +2.8365e+01, -7.1836e+04, -1.7947e+05, +2.5073e+08, +1.9029e+09, -3.3936e+12, +1.2829e+16],
+        ['BC', 0.01000, 0.09814, -7.2919e-07, -2.5788e-02, -5.4243e+00, +1.8297e+01, -3.6399e+04, -1.8928e+05, +2.7961e+08, +1.5270e+09, -3.1054e+12, +1.1735e+16],
+        ['BC', 0.01000, 0.07568, -1.8658e-06, -2.4549e-02, -3.7961e+00, +7.9939e+00, -1.8270e+04, -9.0518e+04, +2.3235e+08, +8.1040e+08, -2.4656e+12, +9.3410e+15],
+        ['BC', 0.01000, 0.05755, -6.9437e-07, -1.9501e-02, -2.2458e+00, +2.9742e+00, -1.0525e+04, -1.8749e+04, +1.6339e+08, +2.9806e+08, -1.6673e+12, +6.2159e+15],
+        ['BC', 0.01000, 0.04544, -1.2861e-07, -1.2764e-03, -8.7276e-01, -4.5371e-01, -5.5830e+03, +2.6585e+04, +9.6483e+07, +1.2858e+06, -1.0053e+12, +3.9069e+15],
+        ['m_accep', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ['BC', 0.03200, 0.11887, -3.6974e-08, +1.2757e-02, +1.1825e+00, +1.8453e+00, -4.6262e+03, +2.4200e+04, +7.3751e+07, -6.3579e+07, -7.8054e+11, +3.0544e+15],
+        ['BC', 0.03200, 0.09720, -9.0591e-07, -1.2063e-01, +5.2835e-01, +1.0917e+01, -3.2323e+03, -1.8683e+03, +4.9009e+07, -4.9946e+07, -4.6379e+11, +1.7988e+15],
+        ['m_accep', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ['BC', 0.16000, 0.62161, -1.1668e-06, -8.9725e-01, +4.4207e-01, +3.2247e+01, +1.9416e+03, -2.8567e+05, -5.0265e+07, +1.4028e+09, +6.1042e+11, -2.5574e+15],
+        ['BC', 0.16000, 0.62274, +2.8034e-07, -9.0717e-01, +2.0879e-01, -6.2815e-01, +1.9822e+03, +2.4218e+05, -4.1507e+07, -1.1837e+09, +4.3276e+11, -1.5769e+15],
+        ['BC', 0.01200, 0.04249, +5.4796e-07, -8.8611e-01, +4.9910e-01, +2.4958e+01, -9.4206e+03, -1.6025e+05, +1.8960e+08, +8.8432e+08, -1.6666e+12, +5.5453e+15],
+        ['BC_EDGE', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ['BC', 0.01400, 0.03339, -4.4895e-07, -4.4684e-01, -1.8750e+00, +2.2077e+01, -5.5912e+03, -1.6748e+05, +1.0327e+08, +9.3221e+08, -8.6332e+11, +2.7550e+15],
+        ['BC', 0.01600, 0.01935, +7.1551e-07, -1.1215e-01, -1.9597e+00, +1.3313e+01, -3.5424e+03, -1.6337e+05, +6.3653e+07, +8.9179e+08, -5.4044e+11, +1.7393e+15],
+        ['BC', 0.03500, 0.01344, -1.7487e-07, -1.9828e-02, -1.2534e+00, +1.9342e+01, +2.8084e+03, -2.9546e+05, -5.0640e+07, +1.4694e+09, +4.0940e+11, -1.2172e+15]
+    ]
+
+    # turns deflection angle error off (convenient for having a nominal model
+    # with zero 4d closed orbit)
+    for i in range(len(segmodel)):
+        segmodel[i][3] = 0.0
+
+    model = []
+
+    # --- creates half model ---
+    d2r = _math.pi/180.0
+    PolyB = _np.zeros(1+max(monomials))
+    for i in range(len(segmodel)):
+        fam_name, element_type = segtypes[segmodel[i][0]]
+        if element_type == _pyaccel.elements.rbend:
+            for j in range(len(monomials)):
+                PolyB[monomials[j]] = segmodel[i][j+3]
+            PolyA = 0 * PolyB
+            element = element_type(fam_name=fam_name, length=segmodel[i][1],
+                                   angle=d2r * segmodel[i][2],
+                                   angle_in=0, angle_out=0,
+                                   gap=0, fint_in=0, fint_out=0,
+                                   polynom_a=PolyA, polynom_b=PolyB)
+        else:
+            element = element_type(fam_name)
+        model.append(element)
+
+    # --- adds additional markers ---
+    mc = segtypes['mc'][1](segtypes['mc'][0])
+    maccep = segtypes['m_accep'][1](segtypes['m_accep'][0])
+    model = model[::-1] + [mc, maccep] + model
+
+    if simplified:
+        m_accep = _pyaccel.elements.marker(m_accep_fam_name)
+        le = sum([s[1] for s in segmodel[:8]])
+        ang1 = sum([s[2] for s in segmodel[:8]]) * d2r
+        k = sum([s[4]*s[1] for s in segmodel[:8]])/le
+        s = sum([s[5]*s[1] for s in segmodel[:8]])/le
+        el = _pyaccel.elements.rbend(fam_name='BC', length=2*le, angle=2*ang1,
+                                     angle_in=0, angle_out=0,
+                                     gap=0, fint_in=0, fint_out=0,
+                                     polynom_a=[0, 0, 0], polynom_b=[0, k, s])
+        le = sum([s[1] for s in segmodel[9:14]])
+        ang2 = sum([s[2] for s in segmodel[9:]]) * d2r
+        k = sum([s[4]*s[1] for s in segmodel[9:]])/le
+        s = sum([s[5]*s[1] for s in segmodel[9:]])/le
+        el_e = _pyaccel.elements.rbend(
+            fam_name='BC', length=le, angle=ang2,
+            angle_in=0, angle_out=0*ang2,
+            gap=0, fint_in=0, fint_out=0,
+            polynom_a=[0, 0, 0], polynom_b=[0, k, s])
+        el_b = _pyaccel.elements.rbend(
+            fam_name='BC', length=le, angle=ang2,
+            angle_in=0*ang2, angle_out=0,
+            gap=0, fint_in=0, fint_out=0,
+            polynom_a=[0, 0, 0], polynom_b=[0, k, s])
+        l2 = sum([s[1] for s in segmodel[14:]])
+        dr = _pyaccel.elements.drift('LBC', l2)
+        model = [dr, el_b, m_accep, el, m_accep, el_e, dr]
+
+    return model
+
+
+def dipole_b1(m_accep_fam_name, simplified=False):
+    """Segmented B1 dipole model."""
+    segtypes = {
+        'B1': ('B1', _pyaccel.elements.rbend),
+        'B1_EDGE': ('B1_EDGE', _pyaccel.elements.marker),
+        'mb1': ('mb1', _pyaccel.elements.marker),
+        'm_accep': (m_accep_fam_name, _pyaccel.elements.marker),
+    }
+
+    # Average Dipole Model for B1 at current 403p6A
+    # =============================================
+    # date: 2019-01-30
+    # Based on multipole expansion around average segmented model trajectory
+    # calculated from fieldmap analysis of measurement data
+    # init_rx =  8.527 mm
+    # ref_rx  = 13.693 mm (average model trajectory)
+    # goal_tunes = [49.096188917357331, 14.151971558423915];
+    # goal_chrom = [2.549478494984214, 2.527086095938103];
+
+    monomials = [0, 1, 2, 3, 4, 5, 6]
+    segmodel = [
+        # type     len[m]   angle[deg]  PolyB(n=0)   PolyB(n=1)   PolyB(n=2)   PolyB(n=3)   PolyB(n=4)   PolyB(n=5)   PolyB(n=6)
+        ['B1', 0.00200, 0.00633, -1.9696e-06, -7.2541e-01, -5.4213e-01, +5.4347e+00, +2.5091e+02, +4.9772e+02, -1.9113e+06],
+        ['B1', 0.00300, 0.00951, -3.8061e-06, -7.2968e-01, -4.5292e-01, +4.3822e+00, +3.1863e+02, +1.5282e+03, -2.3387e+06],
+        ['B1', 0.00500, 0.01592, -4.7568e-07, -7.4227e-01, -2.1669e-01, +2.9544e+00, +2.9316e+02, +1.4632e+03, -2.0877e+06],
+        ['B1', 0.00500, 0.01603, -1.9480e-06, -7.5771e-01, -1.0657e-02, +3.5007e+00, +2.9571e+02, -1.7742e+03, -2.0010e+06],
+        ['B1', 0.00500, 0.01611, -2.7633e-06, -7.6662e-01, +3.3285e-02, +4.7919e+00, +3.3381e+02, -3.3109e+03, -2.0402e+06],
+        ['B1', 0.01000, 0.03236, -1.9098e-06, -7.7081e-01, +1.6451e-02, +5.3028e+00, +3.7119e+02, -4.8877e+03, -2.0590e+06],
+        ['B1', 0.04000, 0.12963, -1.6309e-06, -7.7247e-01, +4.8673e-02, +4.6505e+00, +3.3306e+02, -2.1646e+03, -1.5868e+06],
+        ['B1', 0.15000, 0.48382, -1.9888e-06, -7.7332e-01, +9.7601e-02, +5.3336e+00, +2.5126e+02, +8.0649e+02, -9.2335e+05],
+        ['B1', 0.10000, 0.32247, -2.1025e-06, -7.7271e-01, +1.1969e-01, +5.6811e+00, +2.1496e+02, +5.2023e+03, -6.0518e+05],
+        ['B1', 0.05000, 0.16165, -2.1257e-06, -7.7203e-01, +5.6224e-02, +4.5293e+00, +6.3908e+01, +6.1651e+03, +3.4951e+05],
+        ['B1', 0.03400, 0.10509, -1.8623e-06, -7.7144e-01, -1.2160e-01, +9.1976e+00, -5.3231e+01, +9.0360e+03, +7.2783e+05],
+        ['B1_EDGE', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ['B1', 0.01600, 0.03414, -9.6169e-07, -4.5231e-01, -1.8149e+00, +1.9400e+01, -2.2843e+02, +1.6525e+04, -4.0477e+04],
+        ['B1', 0.04000, 0.03296, -5.2504e-07, -8.6643e-02, -1.7536e+00, +8.5147e+00, -5.8350e+01, +4.2954e+03, -3.7834e+04],
+        ['B1', 0.04000, 0.00774, -1.6259e-07, -8.3065e-03, -3.8990e-01, +1.3183e+00, +2.5814e+01, +3.1642e+02, -5.0464e+04],
+        ['B1', 0.05000, 0.00389, -7.9445e-08, -1.0742e-03, -9.8271e-02, +5.0359e-02, -1.0312e+01, +9.0013e+02, +8.2477e+04],
+        ['m_accep', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    ]
+
+    # turns deflection angle error off (convenient for having a nominal model
+    # with zero 4d closed orbit)
+    for i in range(len(segmodel)):
+        segmodel[i][3] = 0.0
+
+    model = []
+
+    # --- creates half model ---
+    d2r = _math.pi/180.0
+    PolyB = _np.zeros(1+max(monomials))
+    for i in range(len(segmodel)):
+        fam_name, element_type = segtypes[segmodel[i][0]]
+        if element_type == _pyaccel.elements.rbend:
+            for j in range(len(monomials)):
+                PolyB[monomials[j]] = segmodel[i][j+3]
+            PolyA = 0 * PolyB
+            element = element_type(fam_name=fam_name, length=segmodel[i][1],
+                                   angle=d2r * segmodel[i][2],
+                                   angle_in=0, angle_out=0,
+                                   gap=0, fint_in=0, fint_out=0,
+                                   polynom_a=PolyA, polynom_b=PolyB)
+        else:
+            element = element_type(fam_name)
+        model.append(element)
+
+    # --- adds additional markers ---
+    mb1 = segtypes['mb1'][1](segtypes['mb1'][0])
+    maccep = segtypes['m_accep'][1](segtypes['m_accep'][0])
+    model = model[::-1] + [mb1, maccep] + model
+
+    if simplified:
+        le = sum([s[1] for s in segmodel[:12]])
+        ang = sum([s[2] for s in segmodel]) * d2r
+        k = sum([s[4]*s[1] for s in segmodel])/le
+        s = sum([s[5]*s[1] for s in segmodel])/le
+        el = _pyaccel.elements.rbend(
+            fam_name='B1', length=2*le, angle=2*ang,
+            angle_in=0*ang, angle_out=0*ang,
+            gap=0, fint_in=0, fint_out=0,
+            polynom_a=[0, 0, 0], polynom_b=[0, k, s])
+        l2 = sum([s[1] for s in segmodel[12:]])
+        dr = _pyaccel.elements.drift('LB1', l2)
+        model = [dr, el, dr]
+
+    return model
+
+
+def dipole_b2(m_accep_fam_name, simplified=False):
+    """Segmented B2 dipole model."""
+    segtypes = {
+        'B2': ('B2', _pyaccel.elements.rbend),
+        'B2_EDGE': ('B2_EDGE', _pyaccel.elements.marker),
+        'mb2': ('mb2', _pyaccel.elements.marker),
+        'm_accep': (m_accep_fam_name, _pyaccel.elements.marker),
+    }
+
+    #  Average Dipole Model for B2 at current 401p8A
+    #  =============================================
+    #  date: 2019-01-30
+    #  Based on multipole expansion around average segmented model trajectory calculated
+    #  from fieldmap analysis of measurement data
+    #  init_rx =  8.153 mm
+    #  ref_rx  = 19.428 mm (average model trajectory)
+    #  goal_tunes = [49.096188917357331, 14.151971558423915];
+    #  goal_chrom = [2.549478494984214, 2.527086095938103];
+
+    monomials = [0, 1, 2, 3, 4, 5, 6]
+    segmodel = [
+        #type     len[m]   angle[deg]  PolyB(n=0)   PolyB(n=1)   PolyB(n=2)   PolyB(n=3)   PolyB(n=4)   PolyB(n=5)   PolyB(n=6)
+        ['B2', 0.12500, 0.40623, +2.8141e-07, -7.7535e-01, +3.8504e-02, +1.7048e+00, -2.6809e+02, +8.8090e+03, +1.8541e+06],
+        ['B2', 0.05500, 0.17963, +2.4869e-07, -7.7400e-01, +1.8903e-02, +1.3538e+00, -2.7871e+02, +8.4667e+03, +1.7913e+06],
+        ['B2', 0.01000, 0.03260, -1.4532e-07, -7.6990e-01, -7.3993e-03, +1.4325e+00, -3.7053e+02, +9.0098e+03, +1.8818e+06],
+        ['B2', 0.00500, 0.01624, -9.6976e-07, -7.6272e-01, -4.4905e-02, +3.7505e-01, -4.0759e+02, +1.0527e+04, +1.8729e+06],
+        ['B2', 0.00500, 0.01619, -8.5112e-08, -7.5413e-01, -1.7000e-01, +1.3254e-01, -4.2095e+02, +1.2650e+04, +1.8762e+06],
+        ['B2', 0.00500, 0.01616, +5.0825e-07, -7.4866e-01, -2.8166e-01, +7.1392e-01, -3.5386e+02, +1.3287e+04, +1.5160e+06],
+        ['m_accep', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ['B2', 0.00500, 0.01618, +1.7001e-06, -7.5218e-01, -2.1312e-01, +3.8486e-01, -3.9031e+02, +1.2889e+04, +1.7072e+06],
+        ['B2', 0.01000, 0.03254, +1.3585e-06, -7.6428e-01, -4.1565e-02, +6.7680e-01, -4.0577e+02, +1.0602e+04, +1.8735e+06],
+        ['B2', 0.01000, 0.03269, +2.9027e-07, -7.7165e-01, -8.0002e-03, +1.7812e+00, -3.2568e+02, +8.2067e+03, +1.7365e+06],
+        ['B2', 0.17500, 0.57073, -1.1637e-07, -7.7428e-01, +6.8988e-02, +4.1024e+00, -5.1871e+01, +7.5752e+02, +5.9943e+05],
+        ['B2', 0.17500, 0.57034, -3.3225e-07, -7.7352e-01, +7.8447e-02, +5.4514e+00, +1.9975e+02, +3.3621e+03, -3.1314e+05],
+        ['B2', 0.02000, 0.06315, +2.2577e-08, -7.8534e-01, -1.4538e-01, +9.2976e+00, -1.5715e+02, +1.2311e+04, +1.1408e+06],
+        ['B2', 0.01000, 0.02719, +8.7645e-08, -6.7626e-01, -3.1354e-01, +1.6050e+01, -3.9938e+02, +1.6288e+04, +8.1085e+05],
+        ['B2_EDGE', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ['B2', 0.01500, 0.02866, +6.3204e-08, -3.6034e-01, -2.3415e+00, +2.0402e+01, -3.9166e+02, +1.9055e+04, +3.1586e+05],
+        ['B2', 0.02000, 0.01994, +5.4460e-07, -1.0711e-01, -2.1654e+00, +1.1296e+01, -1.7816e+02, +7.2357e+03, +1.6786e+05],
+        ['B2', 0.03000, 0.01188, +1.3393e-07, -2.3886e-02, -8.9207e-01, +3.8284e+00, -1.5146e+01, +5.3693e+02, +7.8230e+04],
+        ['B2', 0.03200, 0.00444, -2.8999e-07, -4.5556e-03, -2.6166e-01, +7.8754e-01, +1.5573e+00, +8.3579e+01, +3.8831e+04],
+        ['B2', 0.03250, 0.00341, -1.3468e-07, -1.2481e-03, -1.3069e-01, +3.6679e-01, +1.3671e+01, -7.7370e+02, -2.9544e+04],
+        ['m_accep', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    ]
+
+    # turns deflection angle error off (convenient for having a nominal model
+    # with zero 4d closed orbit)
+    for i in range(len(segmodel)):
+        segmodel[i][3] = 0.0
+
+    model = []
+
+    # --- creates half model ---
+    d2r = _math.pi/180.0
+    PolyB = _np.zeros(1+max(monomials))
+    for i in range(len(segmodel)):
+        fam_name, element_type = segtypes[segmodel[i][0]]
+        if element_type == _pyaccel.elements.rbend:
+            for j in range(len(monomials)):
+                PolyB[monomials[j]] = segmodel[i][j+3]
+            PolyA = 0 * PolyB
+            element = element_type(
+                fam_name=fam_name, length=segmodel[i][1],
+                angle=d2r * segmodel[i][2],
+                angle_in=0, angle_out=0,
+                gap=0, fint_in=0, fint_out=0,
+                polynom_a=PolyA, polynom_b=PolyB)
+        else:
+            element = element_type(fam_name)
+        model.append(element)
+
+    # --- adds additional markers ---
+    mb2 = segtypes['mb2'][1](segtypes['mb2'][0])
+    maccep = segtypes['m_accep'][1](segtypes['m_accep'][0])
+    model = model[::-1] + [mb2, maccep] + model
+
+    if simplified:
+        le = sum([s[1] for s in segmodel[:15]])
+        ang = sum([s[2] for s in segmodel]) * d2r
+        k = sum([s[4]*s[1] for s in segmodel])/le
+        s = sum([s[5]*s[1] for s in segmodel])/le
+        el = _pyaccel.elements.rbend(
+                fam_name='B2', length=2*le, angle=2*ang,
+                angle_in=0*ang, angle_out=0*ang,
+                gap=0, fint_in=0, fint_out=0,
+                polynom_a=[0, 0, 0], polynom_b=[0, k, s])
+        l2 = sum([s[1] for s in segmodel[15:]])
+        dr = _pyaccel.elements.drift('LB2', l2)
+        model = [dr, el, dr]
+
+    return model
+
+
+def quadrupole_q14(fam_name, strength, simplified=False):
+    """Segmented Q14 quadrupole model."""
+    segtypes = {
+        fam_name: (fam_name, _pyaccel.elements.quadrupole),
+    }
+
+    # Q14 model
+    # =========
+    # this (half) model is based on fieldmap
+    # '2017-02-24_Q14_Model04_Sim_X=-14_14mm_Z=-500_500mm_Imc=146.6A_Itc=10A.txt'
+    monomials = [1, 5, 9, 13]
+    segmodel = [
+        # type  len[m]   angle[deg]  PolyB(n=1)   PolyB(n=5)   PolyB(n=9)
+        #                            PolyB(n=13)
+        [fam_name, 0.0700, +0.00000, -4.06e+00, +6.38e+04, -1.45e+13,
+         +2.90e+20],
+    ]
+
+    # rescale fieldmap data to strength argument
+    quadidx = monomials.index(1)
+    seg_lens = [segmodel[i][1] for i in range(len(segmodel))]
+    model_length = 2 * sum(seg_lens)
+    fmap_strength = [2*segmodel[i][3+quadidx]*seg_lens[i]/model_length for i in
+                     range(len(segmodel))]
+    rescale = [strength / fmap_strength[i] for i in range(len(segmodel))]
+
+    # --- hard-edge 1-segment model ---
+    model = []
+    i = 0
+    fam_name, element_type = segtypes[segmodel[i][0]]
+    PolyB = _np.zeros(1+max(monomials))
+    for j in range(len(monomials)):
+        PolyB[monomials[j]] = segmodel[i][j+3] * rescale[i]
+    PolyA = 0 * PolyB
+    element = element_type(fam_name=fam_name,
+                           length=2*segmodel[i][1], K=PolyB[1])
+    element.polynom_a = PolyA
+    element.polynom_b = PolyB
+    model.append(element)
+
+    if simplified:
+        model[0].polynom_a = model[0].polynom_a[:3]
+        model[0].polynom_b = model[0].polynom_b[:3]
+
+    return model
+
+
+def quadrupole_q20(fam_name, strength, simplified=False):
+    """Segmented Q20 quadrupole model."""
+    segtypes = {
+        fam_name: (fam_name, _pyaccel.elements.quadrupole),
+    }
+
+    # Q20 model
+    # =========
+    # this (half) model is based on fieldmap
+    # '2017-02-24_Q20_Model05_Sim_X=-14_14mm_Z=-500_500mm_Imc=
+    #  154.66A_Itc=10A.txt'
+    monomials = [1, 5, 9, 13]
+    segmodel = [
+        # type  len[m]   angle[deg]  PolyB(n=1)   PolyB(n=5)   PolyB(n=9)
+        #                                                      PolyB(n=13)
+        [fam_name, 0.1000, +0.00000, -4.74e+00, +8.41e+04, -1.83e+13,
+         +3.47e+20],
+    ]
+
+    # rescale fieldmap data to strength argument
+    quadidx = monomials.index(1)
+    seg_lens = [segmodel[i][1] for i in range(len(segmodel))]
+    model_length = 2 * sum(seg_lens)
+    fmap_strength = [2*segmodel[i][3+quadidx]*seg_lens[i]/model_length for i in
+                     range(len(segmodel))]
+    rescale = [strength / fmap_strength[i] for i in range(len(segmodel))]
+
+    # --- hard-edge 1-segment model ---
+    model = []
+    i = 0
+    fam_name, element_type = segtypes[segmodel[i][0]]
+    PolyB = _np.zeros(1+max(monomials))
+    for j in range(len(monomials)):
+        PolyB[monomials[j]] = segmodel[i][j+3] * rescale[i]
+    PolyA = 0 * PolyB
+    element = element_type(fam_name=fam_name,
+                           length=2*segmodel[i][1], K=PolyB[1])
+    element.polynom_a = PolyA
+    element.polynom_b = PolyB
+    model.append(element)
+
+    if simplified:
+        model[0].polynom_a = model[0].polynom_a[:3]
+        model[0].polynom_b = model[0].polynom_b[:3]
+
+    return model
+
+
+def quadrupole_q30(fam_name, strength, simplified=False):
+    """Segmented Q30 quadrupole model."""
+    segtypes = {
+        fam_name: (fam_name, _pyaccel.elements.quadrupole),
+    }
+
+    # Q30 model
+    # =========
+    # this (half) model is based on fieldmap
+    # '2017-02-24_Q30_Model06_Sim_X=-14_14mm_Z=-500_500mm_Imc=
+    #  153.8A_Itc=10A.txt'
+    monomials = [1, 5, 9, 13]
+    segmodel = [
+        # type  len[m]   angle[deg]  PolyB(n=1)   PolyB(n=5)   PolyB(n=9)
+        #                                                      PolyB(n=13)
+        [fam_name, 0.1500, +0.00000, -4.75e+00, +1.06e+05, -1.95e+13,
+         +3.56e+20],
+    ]
+
+    # rescale fieldmap data to strength argument
+    quadidx = monomials.index(1)
+    seg_lens = [segmodel[i][1] for i in range(len(segmodel))]
+    model_length = 2 * sum(seg_lens)
+    fmap_strength = [2*segmodel[i][3+quadidx]*seg_lens[i]/model_length for i in
+                     range(len(segmodel))]
+    rescale = [strength / fmap_strength[i] for i in range(len(segmodel))]
+
+    # --- hard-edge 1-segment model ---
+    model = []
+    i = 0
+    fam_name, element_type = segtypes[segmodel[i][0]]
+    PolyB = _np.zeros(1+max(monomials))
+    for j in range(len(monomials)):
+        PolyB[monomials[j]] = segmodel[i][j+3] * rescale[i]
+    PolyA = 0 * PolyB
+    element = element_type(fam_name=fam_name,
+                           length=2*segmodel[i][1], K=PolyB[1])
+    element.polynom_a = PolyA
+    element.polynom_b = PolyB
+    model.append(element)
+
+    if simplified:
+        model[0].polynom_a = model[0].polynom_a[:3]
+        model[0].polynom_b = model[0].polynom_b[:3]
+
+    return model

--- a/pymodels/__init__.py
+++ b/pymodels/__init__.py
@@ -6,17 +6,18 @@ from . import TB_V04_01
 from . import BO_V05_04
 from . import TS_V04_01
 from . import SI_V24_04
+from . import SI_V25_01
 from . import coordinate_system
 from . import middlelayer
 
 with open(_os.path.join(__path__[0], 'VERSION'), 'r') as _f:
     __version__ = _f.read().strip()
 
-__all__ = ('LI_V01_01', 'TB_V04_01', 'BO_V05_04', 'TS_V04_01', 'SI_V24_04')
+__all__ = ('LI_V01_01', 'TB_V04_01', 'BO_V05_04', 'TS_V04_01', 'SI_V24_04', 'SI_V25_01')
 
 
 li = LI_V01_01
 tb = TB_V04_01
 bo = BO_V05_04
 ts = TS_V04_01
-si = SI_V24_04
+si = SI_V25_01


### PR DESCRIPTION
- new circumference (long straight sections adapted)
- original tunes
- original chroms
- added file with lattice version history from MML. pyaccel will be the primary source for this file.

ps1: quad strengths from MAD simmetrization lacking.
ps2: as discussed with @murilobalves , we think it is a good option to keep previous model versions as importable subpackages.